### PR TITLE
Api uastring

### DIFF
--- a/specs/APIReview_UAString.md
+++ b/specs/APIReview_UAString.md
@@ -10,9 +10,11 @@ However, there are a couple limitations to this workaround-- it is not an API th
 
 # Description
 
-The User Agent (UA) is a client-side piece of information regarding the user's OS, application, and version. The browser/webcontrol sends the User Agent to the HTTP server.
+The User Agent (UA) is a piece of information regarding the user's OS, application, and version. The browser/webcontrol sends the User Agent to the HTTP server.
 
-The User Agent property lets developers modify WebView2's User Agent. A key scenario is to allow end developers to get the current User Agent from the WebView and modify it based on an event, such as navigating to a specific website and setting the User Agent to emulate a different browser version.
+The User Agent property lets developers modify WebView2's User Agent. A key scenario is to allow end developers to get the current User Agent from the WebView and modify it based on an event. 
+
+Ex. Update the User Agent to emulate a different browser version upon navigation to a specific website.
 
 # Examples
 

--- a/specs/APIReview_UAString.md
+++ b/specs/APIReview_UAString.md
@@ -40,7 +40,6 @@ m_webView->add_NavigationStarting(
                 // Change the user agent back to desktop
                 CHECK_FAILURE(settings->put_UserAgent(GetDesktopUserAgent()));
             }
-            CoTaskMemFree(temp_uri);
             return S_OK;
         })
         .Get(),

--- a/specs/APIReview_UAString.md
+++ b/specs/APIReview_UAString.md
@@ -57,14 +57,11 @@ private void SetUserAgent(CoreWebView2 sender, CoreWebView2NavigationStartingEve
 {
     var settings = webView2Control.CoreWebView2.Settings;
     // Note: Oversimplified test. Need to support idn, case-insensitivity, etc.
-   if (new Uri(e.Uri).Host == "fourthcoffee.com")
-   {
-      settings.UserAgent = GetMobileUserAgent();
-   }
-   else
-   {
-      settings.UserAgent = GetDesktopUserAgent();
-   }
+    if (new Uri(e.Uri).Host == "fourthcoffee.com") {
+        settings.UserAgent = GetMobileUserAgent();
+    } else {
+        settings.UserAgent = GetDesktopUserAgent();
+    }
 }
 ```
 

--- a/specs/APIReview_UAString.md
+++ b/specs/APIReview_UAString.md
@@ -52,11 +52,12 @@ m_webView->add_NavigationStarting(
 
 ```c #
 webView2Control.NavigationStarting += SetUserAgent;
+
 private void SetUserAgent(CoreWebView2 sender, CoreWebView2NavigationStartingEventArgs e)
 {
     var settings = webView2Control.CoreWebView2.Settings;
     // Note: Oversimplified test. Need to support idn, case-insensitivity, etc.
-   if (new Uri(e.Uri).Host == "contoso.com")
+   if (new Uri(e.Uri).Host == "fourthcoffee.com")
    {
       settings.UserAgent = GetMobileUserAgent();
    }
@@ -77,7 +78,7 @@ See [API Details](#api-details) section below for API reference.
     
 ```IDL
 // This is the ICoreWebView2Settings interface.
-[uuid(c79ba37e-9bd6-4b9e-b460-2ced163f231f), object, pointer_default(unique)]
+[uuid(684cbeef-47ba-4d4a-99f4-976113f9f10a), object, pointer_default(unique)]
 interface ICoreWebView2Settings2 : ICoreWebView2Settings {
     /// `UserAgent` .  Returns the User Agent. The default value is the
     /// default User Agent of the Edge browser.


### PR DESCRIPTION
api review fixes - update description to clarify user agent is set before upon navigation, remove "client side" association with information as it is potentially misleading (information is exposed in DOM), and fixes from api review. 