### PR TITLE
Add browser PID to BrowserProcessExitedEventArgs

### DIFF
--- a/specs/BrowserProcessExited.md
+++ b/specs/BrowserProcessExited.md
@@ -5,7 +5,7 @@ additional work on the host app, so we are proposing the `BrowserProcessExited`
 event. The `ProcessFailed` event already lets app developers handle unexpected
 browser process exits for a WebView; this new API lets you listen to both
 expected and unexpected termination of the collection of processes associated to
-a `CoreWebView2Environment` so you can, e.g., cleanup the user data folder when
+a `CoreWebView2Environment` so you can, for example, cleanup the user data folder when
 it's no longer in use. In this document we describe the new API. We'd appreciate
 your feedback.
 
@@ -305,7 +305,7 @@ interface ICoreWebView2Environment3 : ICoreWebView2Environment2
   /// Add an event handler for the `BrowserProcessExited` event.
   /// The `BrowserProcessExited` event is raised when the collection of WebView2
   /// Runtime processes associated to this environment terminate due to a
-  /// browser process error or normal shutdown (e.g., when all associated
+  /// browser process error or normal shutdown (for example, when all associated
   /// WebViews are closed), after all resources (including the user data folder)
   /// have been released.
   ///
@@ -390,7 +390,7 @@ namespace Microsoft.Web.WebView2.Core
 
         /// `BrowserProcessExited` is raised when the collection of WebView2
         /// Runtime processes associated to this `CoreWebView2Environment` terminate due to a
-        /// browser process error or normal shutdown (e.g., when all associated
+        /// browser process error or normal shutdown (for example, when all associated
         /// WebViews are closed), after all resources (including the user data folder)
         /// have been released.
         ///
@@ -439,7 +439,7 @@ handler for `BrowserProcessExited` will only be interested in the next single
 time the browser process exits (even if there could be more browser processes
 being created and exiting throughout the lifetime of a
 `CoreWebView2Environment`). For this reason, we also consider making this event
-an async method instead (e.g., `RegisterWaitForBrowserProcessExit`).
+an async method instead (for example, `RegisterWaitForBrowserProcessExit`).
 
 While there would be no operation started on calling the async method, a handler
 would be a added to be run (only) the next time the browser process associated

--- a/specs/BrowserProcessExited.md
+++ b/specs/BrowserProcessExited.md
@@ -61,13 +61,19 @@ class AppWindow {
 
 HRESULT AppWindow::OnCreateCoreWebView2ControllerCompleted(HRESULT result, ICoreWebView2Controller* controller)
 {
-  // ...
+  if (result == S_OK)
+  {
+    // ...
 
-  // Save PID of the browser process serving last WebView created from our
-  // CoreWebView2Environment.
-  CHECK_FAILURE(m_webView->get_BrowserProcessId(&m_newestBrowserPid));
+    // Save PID of the browser process serving last WebView created from our
+    // CoreWebView2Environment. We know the controller was created with
+    // S_OK, and it hasn't been closed (we haven't called Close and no
+    // ProcessFailed event could have been raised yet) so the PID is
+    // available.
+    CHECK_FAILURE(m_webView->get_BrowserProcessId(&m_newestBrowserPid));
 
-  // ...
+    // ...
+  }
 }
 
 void AppWindow::CloseWebView(/* ... */) {

--- a/specs/BrowserProcessExited.md
+++ b/specs/BrowserProcessExited.md
@@ -108,10 +108,13 @@ void AppWindow::CloseWebView(/* ... */) {
           {
             // The exiting process is not the last in use. Do not attempt cleanup
             // as we might still have a webview open over the user data folder.
-            MessageBox(
-                m_mainWindow,
-                L"A new browser process prevented cleanup of the user data folder.",
-                L"Cleanup User Data Folder", MB_OK);
+            // Do not block from event handler.
+            RunAsync([this]() {
+                MessageBox(
+                    m_mainWindow,
+                    L"A new browser process prevented cleanup of the user data folder.",
+                    L"Cleanup User Data Folder", MB_OK);
+            });
           }
 
           return S_OK;

--- a/specs/BrowserProcessExited.md
+++ b/specs/BrowserProcessExited.md
@@ -263,12 +263,13 @@ void ReinitializeWebView()
 
 # Remarks
 Note this is an event from `CoreWebView2Environment`, not `CoreWebView2`. The
-difference between this `BrowserProcessExited` event and the `CoreWebView2`'s
-`ProcessFailed` event is that `BrowserProcessExited` is raised for any (expected
-and unexpected) **browser process** (along its associated processes) exits,
-while `ProcessFailed` is raised only for **unexpected** browser process exits,
-or for **render process** exits/unresponsiveness. To learn more about the
-WebView2 Process Model, go to [Process model](https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/process-model).
+difference between `BrowserProcessExited` and `CoreWebView2`'s `ProcessFailed`
+is that `BrowserProcessExited` is raised for any **browser process** exit
+(expected or unexpected, after all associated processes have exited too), while
+`ProcessFailed` is raised for **unexpected** process exits of any kind (browser,
+render, GPU, and all other types), or for main frame **render process**
+unresponsiveness. To learn more about the WebView2 Process Model, go to
+[Process model](https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/process-model).
 
 In the case the browser process crashes, both `BrowserProcessExited` and
 `ProcessFailed` events are raised, but the order is not guaranteed.
@@ -322,13 +323,14 @@ interface ICoreWebView2Environment3 : ICoreWebView2Environment2
   /// one process should not clear the user data folder at the same time that another
   /// process recovers from a crash by recreating its WebView controls.
   ///
-  /// Note this is an event from the `ICoreWebView2Environment3` interface, not the
-  /// `ICoreWebView2`. The difference between this `BrowserProcessExited` event and
-  /// the `ICoreWebView2`'s `ProcessFailed` event is that `BrowserProcessExited` is
-  /// raised for any (expected and unexpected) **browser process** (along its
-  /// associated processes) exits, while `ProcessFailed` is raised only for
-  /// **unexpected** browser process exits, or for **render process**
-  /// exits/unresponsiveness. To learn more about the WebView2 Process Model, go to
+  /// Note this is an event from the `ICoreWebView2Environment3` interface, not
+  /// the `ICoreWebView2` one. The difference between `BrowserProcessExited` and
+  /// `ICoreWebView2`'s `ProcessFailed` is that `BrowserProcessExited` is
+  /// raised for any **browser process** exit (expected or unexpected, after all
+  /// associated processes have exited too), while `ProcessFailed` is raised for
+  /// **unexpected** process exits of any kind (browser, render, GPU, and all
+  /// other types), or for main frame **render process** unresponsiveness. To
+  /// learn more about the WebView2 Process Model, go to
   /// [Process model](https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/process-model).
   ///
   /// In the case the browser process crashes, both `BrowserProcessExited` and
@@ -404,11 +406,12 @@ namespace Microsoft.Web.WebView2.Core
         /// process recovers from a crash by recreating its WebView controls.
         ///
         /// Note this is an event from `CoreWebView2Environment`, not `CoreWebView2`. The
-        /// difference between this `BrowserProcessExited` event and the `CoreWebView2`'s
-        /// `ProcessFailed` event is that `BrowserProcessExited` is raised for any (expected
-        /// and unexpected) **browser process** (along its associated processes) exits, while
-        /// `ProcessFailed` is raised only for **unexpected** browser process exits, or for
-        /// **render process** exits/unresponsiveness. To learn more about the WebView2
+        /// difference between `BrowserProcessExited` and `CoreWebView2`'s 
+        /// `ProcessFailed` is that `BrowserProcessExited` is raised for any **browser process** exit
+        /// (expected or unexpected, after all associated processes have exited too), while
+        /// `ProcessFailed` is raised  for **unexpected** process exits of any kind (browser,
+        /// render, GPU, and all other types), or for main frame **render process**
+        /// unresponsiveness. To learn more about the WebView2
         /// Process Model, go to [Process model](https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/process-model).
         ///
         /// In the case the browser process crashes, both `BrowserProcessExited` and

--- a/specs/BrowserProcessExited.md
+++ b/specs/BrowserProcessExited.md
@@ -314,10 +314,11 @@ interface ICoreWebView2Environment3 : ICoreWebView2Environment2
 
   /// Add an event handler for the `BrowserProcessExited` event.
   /// The `BrowserProcessExited` event is raised when the collection of WebView2
-  /// Runtime processes associated to this environment terminate due to a
-  /// browser process error or normal shutdown (for example, when all associated
-  /// WebViews are closed), after all resources (including the user data folder)
-  /// have been released.
+  /// Runtime processes for the browser process of this environment terminate
+  /// due to browser process failure or normal shutdown (for example, when all
+  /// associated WebViews are closed), after all resources have been released
+  /// (including the user data folder). To learn about what these processes are,
+  /// go to [Process model](https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/process-model).
   ///
   /// A handler added with this method is called until removed with
   /// `remove_BrowserProcessExited`, even if a new browser process is bound to
@@ -403,10 +404,11 @@ namespace Microsoft.Web.WebView2.Core
         // ...
 
         /// `BrowserProcessExited` is raised when the collection of WebView2
-        /// Runtime processes associated to this `CoreWebView2Environment` terminate due to a
-        /// browser process error or normal shutdown (for example, when all associated
-        /// WebViews are closed), after all resources (including the user data folder)
-        /// have been released.
+        /// Runtime processes for the browser process of this `CoreWebView2Environment`
+        /// terminate due to browser process failure or normal shutdown (for example,
+        /// when all associated WebViews are closed), after all resources have been
+        /// released (including the user data folder). To learn about what these processes
+        /// are, go to [Process model](https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/process-model).
         ///
         /// Multiple app processes can share a browser process by creating their webviews
         /// from a `CoreWebView2Environment` with the same user data folder. When the entire

--- a/specs/BrowserProcessExited.md
+++ b/specs/BrowserProcessExited.md
@@ -32,14 +32,17 @@ different scenarios. It is up to the app to coordinate the handlers so they do
 not try to perform reliability recovery while also trying to move to a new
 WebView2 Runtime version or remove the user data folder.
 
-Multiple app processes can share a browser process by creating their
-`CoreWebView2Environment` with the same user data folder. When the entire
-collection of WebView2Runtime processes sharing the browser process exit, all
-associated `CoreWebview2Environment` objects receive the `BrowserProcessExited`
+Multiple app processes can share a browser process by creating their webviews
+from a `CoreWebView2Environment` with the same user data folder. When the entire
+collection of WebView2Runtime processes for the browser process exit, all
+associated `CoreWebView2Environment` objects receive the `BrowserProcessExited`
 event. Multiple processes sharing the same browser process need to coordinate
-their use of the shared user data folder to avoid race conditions. For example,
-one process should not clear the user data folder at the same time that another
-process recovers from a crash by recreating its WebView controls.
+their use of the shared user data folder to avoid race conditions and
+unnecessary waits. For example, one process should not clear the user data
+folder at the same time that another process recovers from a crash by recreating
+its WebView controls; one process should not block waiting for the event if
+other app processes are using the same browser process (the browser process will
+not exit until those other processes have closed their webviews too).
 
 
 # Examples
@@ -314,14 +317,17 @@ interface ICoreWebView2Environment3 : ICoreWebView2Environment2
   /// `remove_BrowserProcessExited`, even if a new browser process is bound to
   /// this environment after earlier `BrowserProcessExited` events are raised.
   ///
-  /// Multiple app processes can share a browser process by creating their
-  /// `ICoreWebView2Environment` with the same user data folder. When the entire
-  /// collection of WebView2Runtime processes sharing the browser process exit, all
-  /// associated `ICoreWebview2Environment` objects receive the `BrowserProcessExited`
+  /// Multiple app processes can share a browser process by creating their webviews
+  /// from a `ICoreWebView2Environment` with the same user data folder. When the entire
+  /// collection of WebView2Runtime processes for the browser process exit, all
+  /// associated `ICoreWebView2Environment` objects receive the `BrowserProcessExited`
   /// event. Multiple processes sharing the same browser process need to coordinate
-  /// their use of the shared user data folder to avoid race conditions. For example,
-  /// one process should not clear the user data folder at the same time that another
-  /// process recovers from a crash by recreating its WebView controls.
+  /// their use of the shared user data folder to avoid race conditions and
+  /// unnecessary waits. For example, one process should not clear the user data
+  /// folder at the same time that another process recovers from a crash by recreating
+  /// its WebView controls; one process should not block waiting for the event if
+  /// other app processes are using the same browser process (the browser process will
+  /// not exit until those other processes have closed their webviews too).
   ///
   /// Note this is an event from the `ICoreWebView2Environment3` interface, not
   /// the `ICoreWebView2` one. The difference between `BrowserProcessExited` and
@@ -396,14 +402,17 @@ namespace Microsoft.Web.WebView2.Core
         /// WebViews are closed), after all resources (including the user data folder)
         /// have been released.
         ///
-        /// Multiple app processes can share a browser process by creating their
-        /// `CoreWebView2Environment` with the same user data folder. When the entire
-        /// collection of WebView2Runtime processes sharing the browser process exit, all
-        /// associated `CoreWebview2Environment` objects receive the `BrowserProcessExited`
+        /// Multiple app processes can share a browser process by creating their webviews
+        /// from a `CoreWebView2Environment` with the same user data folder. When the entire
+        /// collection of WebView2Runtime processes for the browser process exit, all
+        /// associated `CoreWebView2Environment` objects receive the `BrowserProcessExited`
         /// event. Multiple processes sharing the same browser process need to coordinate
-        /// their use of the shared user data folder to avoid race conditions. For example,
-        /// one process should not clear the user data folder at the same time that another
-        /// process recovers from a crash by recreating its WebView controls.
+        /// their use of the shared user data folder to avoid race conditions and
+        /// unnecessary waits. For example, one process should not clear the user data
+        /// folder at the same time that another process recovers from a crash by recreating
+        /// its WebView controls; one process should not block waiting for the event if
+        /// other app processes are using the same browser process (the browser process will
+        /// not exit until those other processes have closed their webviews too).
         ///
         /// Note this is an event from `CoreWebView2Environment`, not `CoreWebView2`. The
         /// difference between `BrowserProcessExited` and `CoreWebView2`'s 


### PR DESCRIPTION
Adding `BrowserProcessId` property to `CoreWebView2BrowserProcessExitedEventArgs`.

CoreWebView2Environment can attach to multiple browser processes throughout its lifetime. When repeatedly creating and closing a single WebView from the same environment, a new browser process could be created each time. The `BrowserProcessId` lets apps tracking the browser exit know the PID of the browser process for which the `BrowserProcessExited` event was raised.