### PR TITLE
API review for custom scheme registration 

### DIFF
--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -300,7 +300,7 @@ interface ICoreWebView2CustomSchemeRegistration : IUnknown {
   // and `?` (matches 0 or 1 character) wildcards just like the URI matching in the
   // [AddWebResourceRequestedFilter API](https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.addwebresourcerequestedfilter).
   // For example, "http://*.example.com:80".
-  // The array of strings and the array here must be deallocated with CoTaskMemFree.
+  // The returned strings and the array itself must be deallocated with CoTaskMemFree.
   HRESULT GetAllowedOrigins([out] UINT32* allowedOriginsCount, [out] LPCWSTR** allowedOrigins);
   // Set the array of origins that are allowed to use the scheme.
   HRESULT SetAllowedOrigins([in] UINT32 allowedOriginsCount, [in] LPCWSTR* allowedOrigins);

--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -2,18 +2,43 @@ RegisterCustomScheme
 ===
 
 # Background
-Currently the WebResourceRequested event is not raised for non-http(s) URIs. Spartan WebView has built-in support for ms-appx* URIs and support of providing an IUriToStreamResolver parameter in NavigateToLocalStreamUri. Raising the CoreWebView2.WebResourceRequested for custom scheme URIs would close the functional gap between WebView1 and WebView2 as the app can just provide a WebResourceResponse for a given custom scheme URI.
+Currently the WebResourceRequested event is not raised for non-http(s) URIs.
+Spartan WebView has built-in support for ms-appx* URIs and support of providing
+an IUriToStreamResolver parameter in NavigateToLocalStreamUri. Raising the
+CoreWebView2.WebResourceRequested for custom scheme URIs would close the
+functional gap between WebView1 and WebView2 as the app can just provide a
+WebResourceResponse for a given custom scheme URI.
 
-To be able to provide the ability to raise WebResourceRequested for custom schemes, WebView2 needs to be able to know how to treat such custom scheme URIs. By the W3C standard, custom schemes have opaque origins and do not participate in security policies. However, in order to make web requests with custom schemes useful, some of these URIs would need to act more like HTTP URIs, while keeping security in mind. The following questions arise:
+To be able to provide the ability to raise WebResourceRequested for custom
+schemes, WebView2 needs to be able to know how to treat such custom scheme URIs.
+By the W3C standard, custom schemes have opaque origins and do not participate
+in security policies. However, in order to make web requests with custom schemes
+useful, some of these URIs would need to act more like HTTP URIs, while keeping
+security in mind. The following questions arise:
 
 - Are custom scheme URIs considered secure contexts?
-- Which origins should be able to issue requests from these custom schemes to prevent an untrusted origin from reading trusted data from the app?
+- Which origins should be able to issue requests for these custom schemes to
+  prevent an untrusted origin from reading trusted data from the app?
 
-As a result, we introduce a new API to be able to register custom schemes and allow the end developer to answer these questions as a part of registration.
+As a result, we introduce a new API to be able to register custom schemes and
+allow the end developer to answer these questions as a part of registration.
 
 # Conceptual pages (How To)
 
-WebResourceRequested event can also be raised for custom schemes. For this, the app has to register the custom schemes it would like to be able to issue resource requests for. With each registration, the app will specify whether the URIs with such schemes are considered secure context and it will also need to explicitly specify the origins that are allowed to make requests to these custom scheme URIs to ensure that untrusted origins cannot read trusted data from the app. The registrations are valid throughout the lifetime of the CoreWebView2Environment and browser process and any other CoreWebView2Environments that share the browser process must register exactly same schemes to be able to create a CoreWebView2Environment. The registered custom schemes also participate in [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) and [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
+WebResourceRequested event can also be raised for custom schemes. For this, the
+app has to register the custom schemes it would like to be able to issue
+resource requests for. With each registration, the app will specify whether the
+URIs with such schemes are considered [secure
+context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)
+and it will also need to explicitly specify the origins that are allowed to make
+requests to these custom scheme URIs to ensure that untrusted origins cannot
+read trusted data from the app. The registrations are valid throughout the
+lifetime of the CoreWebView2Environment and browser process and any other
+CoreWebView2Environments that share the browser process must register exactly
+same schemes to be able to create a CoreWebView2Environment. The registered
+custom schemes also participate in
+[CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) and
+[CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
 
 For each custom scheme the developer wants to register they can:
 - Set it to be a secure context scheme to prevent insecure content warnings.
@@ -23,74 +48,117 @@ For each custom scheme the developer wants to register they can:
 
 ## CustomSchemeRegistrations
 
-The following code sample registers 2 custom schemes on the CoreWebView2EnvironmentOptions:
+The following code sample registers 2 custom schemes on the
+CoreWebView2EnvironmentOptions:
 
 - Scheme 1 has https://*.example.com in its allowed origins list.
 - Scheme 2 has a null allowed origins list.
 
-It adds a WebResourceRequested handler for the requests to the custom schemes, which will serve the requests locally. Then it navigates the WebView2 to https://www.example.com and attempts to use XMLHttpRequest (XHR) with both schemes. Only XHR to scheme 1 will succeed because it's the one that has https://www.example.com in its allowed origin list.
+It adds a WebResourceRequested handler for the requests to the custom schemes,
+which will serve the requests locally. Then it navigates the WebView2 to
+https://www.example.com and attempts to use XMLHttpRequest (XHR) with both
+schemes. Only XHR to scheme 1 will succeed because it's the one that has
+https://www.example.com in its allowed origin list.
 ``` c#
 CoreWebView2EnvironmentOptions options = new CoreWebView2EnvironmentOptions();
 string[] allowedOriginsList = new string[1];
 allowedOriginsList[0] = "https://*.example.com";
-
-options.CustomSchemeRegistrations.Add(new CoreWebView2CustomSchemeRegistration("custom-scheme", true /* isSecure */, allowedOriginsList));
-options.CustomSchemeRegistrations.Add(new CoreWebView2CustomSchemeRegistration("custom-scheme-not-in-allowed-origins", true /* isSecure */, null));
-...
 string customScheme = "custom-scheme";
+string customSchemeNotInAllowedOrigins = "custom-scheme-not-in-allowed-origins";
+
+options.CustomSchemeRegistrations.Add(
+  new CoreWebView2CustomSchemeRegistration(customScheme)
+  {
+    TreatAsSecure = true,
+    AllowedOrigins = { "https://*.example.com" }
+  });
+options.CustomSchemeRegistrations.Add(
+  new CoreWebView2CustomSchemeRegistration(customSchemeNotInAllowedOrigins)
+  {
+    TreatAsSecure = true
+  });
+...
+
 webView.CoreWebView2.AddWebResourceRequestedFilter(
         customScheme + ":*", All);
+webView.CoreWebView2.AddWebResourceRequestedFilter(
+        customSchemeNotInAllowedOrigins + ":*", All);
 webView.CoreWebView2.WebResourceRequested += delegate (
-            object sender, CoreWebView2WebResourceRequestedEventArgs e) {
-        CoreWebView2WebResourceResponse response;
-        CoreWebView2WebResourceRequest request = e.Request;
-        String uri = request.uri;
-        if (uri.StartsWith(customScheme + "://"))
-        {
-            string assetsFilePath = L"data/";
-            assetsFilePath += uri.Substring(customScheme.Length + 3);
-            FileStream fileStream = new FileStream(assetsFilePath, FileMode.Open, FileAccess.Read);
+            object sender, CoreWebView2WebResourceRequestedEventArgs e)
+{
+    CoreWebView2WebResourceResponse response;
+    CoreWebView2WebResourceRequest request = e.Request;
+    String uri = request.uri;
+    if (uri.StartsWith(customScheme + ":") ||
+        uri.StartsWith(customSchemeNotInAllowedOrigins))
+    {
+        string assetsFilePath = L"data/";
+        assetsFilePath += uri.Substring(customScheme.Length + 1);
+        FileStream fileStream = new FileStream(assetsFilePath,
+                                               FileMode.Open,
+                                               FileAccess.Read);
 
-            if (stream)
-            {
-              e.Response = webView.CoreWebView2.CreateWebResourceResponse(fileStream, 200, "OK", L"Content-Type: application/json\nAccess-Control-Allow-Origin: *");
-            }
-            else
-            {
-                e.Response = webView.CoreWebView2.CreateWebResourceResponse(null, 404, "Not Found", L"");
-            }
+        if (stream)
+        {
+            e.Response = webView.CoreWebView2.CreateWebResourceResponse(
+                fileStream,
+                200,
+                "OK",
+                "Content-Type: application/json\nAccess-Control-Allow-Origin: *");
         }
+        else
+        {
+            e.Response = webView.CoreWebView2.CreateWebResourceResponse(
+                null,
+                404,
+                "Not Found",
+                "");
+        }
+    }
 }
 
 webView.CoreWebView2.Navigate(L"https://www.example.com");
 
-// The following XHR will execute in the context of https://www.example.com page and will succeed.
-// WebResourceRequested event will be raised for this request as *.example.com is in the allowed origin list of custom-scheme.
-// Since the response header provided in WebResourceRequested handler allows all origins for CORS
-// the XHR succeeds.
-webView.CoreWebView2.ExecuteScriptAsync("var oReq = new XMLHttpRequest();\
-                                        oReq.addEventListener(\"load\", reqListener);\
-                                        oReq.open(\"GET\", \"custom-scheme://example-data.json\");\
-                                        oReq.send();");
-// The following XHR will fail because *.example.com is in the not allowed origin list of custom-scheme2.
-// The WebResourceRequested event will not be raised for this request.
-webView.CoreWebView2.ExecuteScriptAsync("var oReq = new XMLHttpRequest();\
-                                        oReq.addEventListener(\"load\", reqListener);\
-                                        oReq.open(\"GET\", \"custom-scheme-not-in-allowed-origins://example-data.json\");\
-                                        oReq.send();");
+// The following XHR will execute in the context of https://www.example.com page
+// and will succeed.
+// WebResourceRequested event will be raised for this request as *.example.com
+// is in the allowed origin list of custom-scheme.
+// Since the response header provided in WebResourceRequested handler allows all
+// origins for CORS the XHR succeeds.
+webView.CoreWebView2.ExecuteScriptAsync(
+  "var oReq = new XMLHttpRequest();\
+  oReq.addEventListener(\"load\", reqListener);\
+  oReq.open(\"GET\", \"custom-scheme:example-data.json\");\
+  oReq.send();");
+// The following XHR will fail because *.example.com is in the not allowed
+// origin list of custom-scheme2. The WebResourceRequested event will not be
+// raised for this request.
+webView.CoreWebView2.ExecuteScriptAsync(
+  "var oReq = new XMLHttpRequest();\
+  oReq.addEventListener(\"load\", reqListener);\
+  oReq.open(\"GET\", \"custom-scheme-not-in-allowed-origins:example-data.json\");\
+  oReq.send();");
 ```
 
 ``` cpp
 Microsoft::WRL::ComPtr<ICoreWebView2EnvironmentOptions3> options3;
 if (options.As(&options3) == S_OK) {
   std::vector<Microsoft::WRL::ComPtr<ICoreWebView2CustomSchemeRegistration>> schemeRegistrations;
-  
+
   const WCHAR* allowedOrigins[1] = {L"https://*.example.com"};
-  schemeRegistrations.push_back(Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(
-          L"custom-scheme", TRUE /* isSecure*/, 1, allowedOrigins));
-  schemeRegistrations.push_back(Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(
-          L"custom-scheme-not-in-allowed-origins-list", TRUE /* isSecure*/, nullptr));
-  CHECK_FAILURE(options3->SetCustomSchemeRegistrations(schemeRegistrations.size(), schemeRegistrations.data());
+  schemeRegistrations.push_back(
+    Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(
+          L"custom-scheme",
+          TRUE /* treatAsSecure*/,
+          1,
+          allowedOrigins));
+  schemeRegistrations.push_back(
+    Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(
+          L"custom-scheme-not-in-allowed-origins-list",
+          TRUE /* treatAsSecure*/,
+          nullptr));
+  CHECK_FAILURE(options3->SetCustomSchemeRegistrations(
+    schemeRegistrations.size(), schemeRegistrations.data());
 }
 ...
 
@@ -109,7 +177,7 @@ CHECK_FAILURE(m_webView->add_WebResourceRequested(
         if (wcsncmp(uri.get(), L"custom-scheme", ARRAYSIZE(L"custom-scheme")-1) == 0)
         {
             std::wstring assetsFilePath = L"data/";
-            assetsFilePath += wcsstr(uri.get(), L"://") + 3;
+            assetsFilePath += wcsstr(uri.get(), L":") + 1;
             wil::com_ptr<IStream> stream;
             SHCreateStreamOnFileEx(
                 assetsFilePath.c_str(), STGM_READ, FILE_ATTRIBUTE_NORMAL, FALSE,
@@ -119,7 +187,10 @@ CHECK_FAILURE(m_webView->add_WebResourceRequested(
             {
                 CHECK_FAILURE(
                     m_appWindow->GetWebViewEnvironment()->CreateWebResourceResponse(
-                        stream.get(), 200, L"OK", L"Content-Type: application/json\nAccess-Control-Allow-Origin: *",
+                        stream.get(),
+                        200,
+                        L"OK",
+                        L"Content-Type: application/json\nAccess-Control-Allow-Origin: *",
                         &response));
                 CHECK_FAILURE(args->put_Response(response.get()));
             }
@@ -140,26 +211,30 @@ CHECK_FAILURE(m_webView->add_WebResourceRequested(
 
 CHECK_FAILURE(m_webView->Navigate(L"https://www.example.com"));
 
-// The following XHR will execute in the context of https://www.example.com page and will succeed.
-// WebResourceRequested event will be raised for this request as *.example.com is in the allowed origin list of custom-scheme. 
-// Since the response header provided in WebResourceRequested handler allows all origins for CORS
-// the XHR succeeds.
-CHECK_FAILURE(m_webView->ExecuteScript(L"var oReq = new XMLHttpRequest();"
-                                       L"oReq.addEventListener(\"load\", reqListener);"
-                                       L"oReq.open(\"GET\", \"custom-scheme://example-data.json\");"
-                                       L"oReq.send();",
-                                      Callback<ICoreWebView2ExecuteScriptCompletedHandler>(
-                                          [](HRESULT error, PCWSTR result) -> HRESULT { return S_OK; })
-                                          .Get()));
-// The following XHR will fail because *.example.com is not in the allowed origin list of custom-scheme2.
-// The WebResourceRequested event will not be raised for this request.
-CHECK_FAILURE(m_webView->ExecuteScript(L"var oReq = new XMLHttpRequest();"
-                                       L"oReq.addEventListener(\"load\", reqListener);"
-                                       L"oReq.open(\"GET\", \"custom-scheme-not-in-allowed-origins://example-data.json\");"
-                                       L"oReq.send();",
-                                      Callback<ICoreWebView2ExecuteScriptCompletedHandler>(
-                                          [](HRESULT error, PCWSTR result) -> HRESULT { return S_OK; })
-                                          .Get()));
+// The following XHR will execute in the context of https://www.example.com page
+// and will succeed. WebResourceRequested event will be raised for this request
+// as *.example.com is in the allowed origin list of custom-scheme.
+// Since the response header provided in WebResourceRequested handler allows all
+// origins for CORS the XHR succeeds.
+CHECK_FAILURE(m_webView->ExecuteScript(
+                  L"var oReq = new XMLHttpRequest();"
+                  L"oReq.addEventListener(\"load\", reqListener);"
+                  L"oReq.open(\"GET\", \"custom-scheme:example-data.json\");"
+                  L"oReq.send();",
+                  Callback<ICoreWebView2ExecuteScriptCompletedHandler>(
+                    [](HRESULT error, PCWSTR result) -> HRESULT { return S_OK; })
+                    .Get()));
+// The following XHR will fail because *.example.com is not in the allowed
+// origin list of custom-scheme2. The WebResourceRequested event will not be
+// raised for this request.
+CHECK_FAILURE(m_webView->ExecuteScript(
+                  L"var oReq = new XMLHttpRequest();"
+                  L"oReq.addEventListener(\"load\", reqListener);"
+                  L"oReq.open(\"GET\", \"custom-scheme-not-in-allowed-origins:example-data.json\");"
+                  L"oReq.send();",
+                  Callback<ICoreWebView2ExecuteScriptCompletedHandler>(
+                    [](HRESULT error, PCWSTR result) -> HRESULT { return S_OK; })
+                    .Get()));
 ```
 
 # API Details
@@ -178,33 +253,44 @@ interface ICoreWebView2CustomSchemeRegistration : IUnknown {
   // lifetime of the associated WebView2s' browser process and any WebView2
   // environments sharing the browser process must be created with identical
   // custom scheme registrations, otherwise the environment creation will fail.
-  // If there are multiple entries for the same scheme in the registrations list, the environment creation will also fail.
-  // The URIs of registered custom schemes will be treated similar to http URIs for their origins.
+  // If there are multiple entries for the same scheme in the registrations
+  // list, the environment creation will also fail.
+  // The URIs of registered custom schemes will be treated similar to http URIs
+  // for their origins.
   // They will have tuple origins for URIs with host and opaque origins for
   // URIs without host as specified in [7.5 Origin - HTML Living Standard](https://html.spec.whatwg.org/multipage/origin.html)
   // Example:
-  // custom-scheme-with-host://hostname/path/to/resource has origin of custom-scheme-with-host://hostname
-  // custom-scheme-without-host:path/to/resource has origin of custom-scheme-without-host:path/to/resource
-  // For WebResourceRequested event, the cases of request URIs and filter URIs with custom schemes
-  // will be normalized according to generic URI syntax rules. Any non-ASCII characters will be preserved.
-  // The registered custom schemes also participate in [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) and adheres to [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). The app needs to set the appropriate access headers in its WebResourceRequested event handler to allow CORS requests.
+  // custom-scheme-with-host://hostname/path/to/resource has origin of
+  // custom-scheme-with-host://hostname
+  // custom-scheme-without-host:path/to/resource has origin of
+  // custom-scheme-without-host:path/to/resource
+  // For WebResourceRequested event, the cases of request URIs and filter URIs
+  // with custom schemes will be normalized according to generic URI syntax
+  // rules. Any non-ASCII characters will be preserved.
+  // The registered custom schemes also participate in
+  // [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) and adheres
+  // to [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). The app
+  // needs to set the appropriate access headers in its WebResourceRequested
+  // event handler to allow CORS requests.
 
   // The name of the custom scheme to register.
   [propget] HRESULT SchemeName([out, retval] LPCWSTR* schemeName);
   [propput] HRESULT SchemeName([in] LPCWSTR value);
 
-  // Whether the scheme will be treated as a [Secure Context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) like https.
-  [propget] HRESULT IsSecure([out, retval] BOOL* isSecure);
+  // Whether the sites with this scheme will be treated as a
+  // [Secure Context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)
+  // like a HTTPS site.
+  [propget] HRESULT TreatAsSecure([out, retval] BOOL* treatAsSecure);
   // Set if the scheme will be treated as a Secure Context.
-  [propput] HRESULT IsSecure([in] BOOL value);
+  [propput] HRESULT TreatAsSecure([in] BOOL value);
 
   // Array of origins that are allowed to issue requests with the custom scheme.
   // Except origins with this same custom scheme, which are always allowed,
-  // the origin of any request (requests that have the 
+  // the origin of any request (requests that have the
   // [Origin header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin)) to the custom scheme URL
   // needs to be in this list. No-origin requests are requests that do not have an Origin header,
   // such as link navigations, embedded images and are always allowed.
-  // Note that cross-origin restrictions still apply. 
+  // Note that cross-origin restrictions still apply.
   // If the list is empty, no cross-origin request to this scheme is allowed.
   // Origins are specified as a string in the format of scheme://host:port.
   // The origins are string pattern matched with `*` (matches 0 or more characters)
@@ -235,49 +321,66 @@ interface ICoreWebView2EnvironmentOptions3 : IUnknown {
 ```c#
 namespace Microsoft.Web.WebView2.Core
 {
-    // Represents the registration of a custom scheme with the CoreWebView2Environment.
-    // This allows the WebView2 app to be able to handle
-    // WebResourceRequested event for requests with the specified scheme and
-    // be able to navigate the WebView2 to the custom scheme. Once the environment
-    // is created, the registrations are valid and immutable throughout the
-    // lifetime of the associated WebView2s' browser process and any WebView2
-    // environments sharing the browser process must be created with identical
-    // custom scheme registrations, otherwise the environment creation will fail.
+    // Represents the registration of a custom scheme with the
+    // CoreWebView2Environment.
+    // This allows the WebView2 app to be able to handle WebResourceRequested
+    // event for requests with the specified scheme and be able to navigate the
+    // WebView2 to the custom scheme. Once the environment is created, the
+    // registrations are valid and immutable throughout the lifetime of the
+    // associated WebView2s' browser process and any WebView2 environments
+    // sharing the browser process must be created with identical custom scheme
+    // registrations, otherwise the environment creation will fail.
     // Any further attempts to register the same scheme will fail.
-    // The URIs of registered custom schemes will be treated similar to http URIs for their origins.
+    // The URIs of registered custom schemes will be treated similar to http
+    // URIs for their origins.
     // They will have tuple origins for URIs with host and opaque origins for
-    // URIs without host as specified in [7.5 Origin - HTML Living Standard](https://html.spec.whatwg.org/multipage/origin.html)
+    // URIs without host as specified in
+    // [7.5 Origin - HTML Living Standard](https://html.spec.whatwg.org/multipage/origin.html)
     // Example:
-    // `custom-scheme-with-host://hostname/path/to/resource` has origin of `custom-scheme-with-host://hostname`
-    // `custom-scheme-without-host:path/to/resource` has origin of `custom-scheme-without-host:path/to/resource`
-    // For WebResourceRequested event, the cases of request URIs and filter URIs with custom schemes
-    // will be normalized according to generic URI syntax rules. Any non-ASCII characters will be preserved.
-    // The registered custom schemes also participate in [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) and adheres to [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). The app needs to set the appropriate access headers in its WebResourceRequested event handler to allow CORS requests.
+    // `custom-scheme-with-host://hostname/path/to/resource` has origin of
+    // `custom-scheme-with-host://hostname`
+    // `custom-scheme-without-host:path/to/resource` has origin of
+    // `custom-scheme-without-host:path/to/resource`
+    // For WebResourceRequested event, the cases of request URIs and filter URIs
+    // with custom schemes will be normalized according to generic URI syntax
+    // rules. Any non-ASCII characters will be preserved.
+    // The registered custom schemes also participate in
+    // [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) and
+    // adheres to [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
+    // The app needs to set the appropriate access headers in its
+    // WebResourceRequested event handler to allow CORS requests.
     runtimeclass CoreWebView2CustomSchemeRegistration
     {
         // Constructor
-        CoreWebView2CustomSchemeRegistration(string schemeName, bool isSecure, IList<String> allowedOrigins);
+        CoreWebView2CustomSchemeRegistration(String schemeName);
 
         // The name of the custom scheme to register.
-        string SchemeName { get; set; };
+        String SchemeName { get; set; };
 
-        // Whether the scheme will be treated as a [Secure Context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) like https.
-        bool IsSecure { get; set; };
+        // Whether the scheme will be treated as a
+        // [Secure Context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)
+        // like https.
+        Boolean TreatAsSecure { get; set; } = false;
 
         // List of origins that are allowed to issue requests with the custom scheme.
         // Except origins with this same custom scheme, which are always allowed,
-        // the origin of any request (requests that have the 
-        // [Origin header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin)) to the custom scheme URL
-        // needs to be in this list. No-origin requests are requests that do not have an Origin header,
-        // such as link navigations, embedded images and are always allowed.
-        // Note that cross-origin restrictions still apply. 
-        // If the list is empty, no cross-origin request to this scheme is allowed.
-        // Origins are specified as a string in the format of scheme://host:port.
-        // The origins are string pattern matched with `*` (matches 0 or more characters)
-        // and `?` (matches 0 or 1 character) wildcards
-        // just like the URI matching in the [AddWebResourceRequestedFilter API](https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.addwebresourcerequestedfilter).
+        // the origin of any request (requests that have the
+        // [Origin header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin))
+        // to the custom scheme URL needs to be in this list. No-origin requests
+        // are requests that do not have an Origin header, such as link
+        // navigations, embedded images and are always allowed.
+        // Note that cross-origin restrictions still apply.
+        // If the list is empty, no cross-origin request to this scheme is
+        // allowed.
+        // Origins are specified as a string in the format of
+        // scheme://host:port.
+        // The origins are string pattern matched with `*` (matches 0 or more
+        // characters)
+        // and `?` (matches 0 or 1 character) wildcards just like the URI
+        // matching in the
+        // [AddWebResourceRequestedFilter API](https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.addwebresourcerequestedfilter).
         // For example, "http://*.example.com:80".
-        IList<String> AllowedOrigins { get; };
+        IVector<String> AllowedOrigins { get; } = {};
     }
 
     runtimeclass CoreWebView2EnvironmentOptions

--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -87,7 +87,8 @@ auto environmentCreation = CoreWebView2Environment.CreateAsync(
 webView.CoreWebView2.AddWebResourceRequestedFilter(
         customScheme + ":*", CoreWebView2WebResourceContext.All);
 webView.CoreWebView2.AddWebResourceRequestedFilter(
-        customSchemeNotInAllowedOrigins + ":*", CoreWebView2WebResourceContext.All);
+        customSchemeNotInAllowedOrigins + ":*",
+        CoreWebView2WebResourceContext.All);
 webView.CoreWebView2.WebResourceRequested += delegate (
             object sender, CoreWebView2WebResourceRequestedEventArgs e)
 {
@@ -102,14 +103,17 @@ webView.CoreWebView2.WebResourceRequested += delegate (
             FileStream fileStream = new FileStream(assetsFilePath,
                                                 FileMode.Open,
                                                 FileAccess.Read);
-            e.Response = webView.CoreWebView2.Environment.CreateWebResourceResponse(
+            e.Response = webView.CoreWebView2.Environment.
+              CreateWebResourceResponse(
                 fileStream,
                 200,
                 "OK",
-                "Content-Type: application/json\nAccess-Control-Allow-Origin: *");
+                @"Content-Type: application/json\n
+                Access-Control-Allow-Origin: *");
         }
         catch (IOException) {
-            e.Response = webView.CoreWebView2.Environment.CreateWebResourceResponse(
+            e.Response = webView.CoreWebView2.Environment.
+              CreateWebResourceResponse(
                 null,
                 404,
                 "Not Found",
@@ -253,7 +257,7 @@ CHECK_FAILURE(m_webView->ExecuteScript(
 CHECK_FAILURE(m_webView->ExecuteScript(
                   L"var oReq = new XMLHttpRequest();"
                   L"oReq.addEventListener(\"load\", reqListener);"
-                  L"oReq.open(\"GET\", \"custom-scheme-not-in-allowed-origins:example-data.json\");"
+                  L"oReq.open(\"GET\",\"custom-scheme-not-in-allowed-origins:example-data.json\");"
                   L"oReq.send();",
                   Callback<ICoreWebView2ExecuteScriptCompletedHandler>(
                     [](HRESULT error, PCWSTR result) -> HRESULT {
@@ -427,7 +431,8 @@ namespace Microsoft.Web.WebView2.Core
         [interface_name("Microsoft.Web.WebView2.Core.ICoreWebView2EnvironmentOptions3")]
         {
             // List of custom scheme registrations.
-            IVector<CoreWebView2CustomSchemeRegistration> CustomSchemeRegistrations { get; };
+            IVector<CoreWebView2CustomSchemeRegistration>
+              CustomSchemeRegistrations { get; };
         }
     }
 }

--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -92,7 +92,7 @@ webView.CoreWebView2.WebResourceRequested += delegate (
     if (uri.StartsWith(customScheme + ":") ||
         uri.StartsWith(customSchemeNotInAllowedOrigins))
     {
-        string assetsFilePath = L"data/";
+        String assetsFilePath = "data/";
         assetsFilePath += uri.Substring(customScheme.Length + 1);
         FileStream fileStream = new FileStream(assetsFilePath,
                                                FileMode.Open,
@@ -141,6 +141,10 @@ webView.CoreWebView2.ExecuteScriptAsync(
 ```
 
 ``` cpp
+#include <WebView2EnvironmentOptions.h> // CoreWebView2CustomSchemeRegistration is implemented here
+
+...
+
 Microsoft::WRL::ComPtr<ICoreWebView2EnvironmentOptions3> options3;
 if (options.As(&options3) == S_OK) {
   std::vector<Microsoft::WRL::ComPtr<ICoreWebView2CustomSchemeRegistration>> schemeRegistrations;
@@ -285,8 +289,7 @@ interface ICoreWebView2CustomSchemeRegistration : IUnknown {
   [propput] HRESULT TreatAsSecure([in] BOOL value);
 
   // Array of origins that are allowed to issue requests with the custom scheme.
-  // Except origins with this same custom scheme, which are always allowed,
-  // the origin of any request (requests that have the
+  // Except origins with this same custom scheme the origin of any request (requests that have the
   // [Origin header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin)) to the custom scheme URL
   // needs to be in this list. No-origin requests are requests that do not have an Origin header,
   // such as link navigations, embedded images and are always allowed.
@@ -317,7 +320,7 @@ interface ICoreWebView2EnvironmentOptions3 : IUnknown {
 }
 ```
 
-## .NET API
+## WinRT API
 ```c#
 namespace Microsoft.Web.WebView2.Core
 {
@@ -330,7 +333,7 @@ namespace Microsoft.Web.WebView2.Core
     // associated WebView2s' browser process and any WebView2 environments
     // sharing the browser process must be created with identical custom scheme
     // registrations, otherwise the environment creation will fail.
-    // Any further attempts to register the same scheme will fail.
+    // Any further attempts to register the same scheme will fail during environment creation.
     // The URIs of registered custom schemes will be treated similar to http
     // URIs for their origins.
     // They will have tuple origins for URIs with host and opaque origins for
@@ -355,7 +358,7 @@ namespace Microsoft.Web.WebView2.Core
         CoreWebView2CustomSchemeRegistration(String schemeName);
 
         // The name of the custom scheme to register.
-        String SchemeName { get; set; };
+        String SchemeName { get; };
 
         // Whether the scheme will be treated as a
         // [Secure Context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)
@@ -389,7 +392,7 @@ namespace Microsoft.Web.WebView2.Core
         [interface_name("Microsoft.Web.WebView2.Core.ICoreWebView2EnvironmentOptions3")]
         {
             // List of custom scheme registrations.
-            IList<CoreWebView2CustomSchemeRegistration> CustomSchemeRegistrations { get; };
+            IVector<CoreWebView2CustomSchemeRegistration> CustomSchemeRegistrations { get; };
         }
     }
 }


### PR DESCRIPTION
This adds the API spec to be able to register a custom scheme in WebView2. The registered scheme can be used to issue requests that will be handled by the app via the WebResourceRequested event.