### PR TITLE
Add hasAuthorityComponent to CustomSchemeRegistration

### DIFF
--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -76,8 +76,7 @@ options.CustomSchemeRegistrations.Add(
 options.CustomSchemeRegistrations.Add(
   new CoreWebView2CustomSchemeRegistration(customSchemeNotInAllowedOrigins)
   {
-    TreatAsSecure = true,
-    HasAuthorityComponent = true
+    TreatAsSecure = true
   });
 
 // Custom scheme registrations are validated here. In case invalid array is
@@ -135,7 +134,7 @@ webView.CoreWebView2.Navigate("https://www.example.com");
 webView.CoreWebView2.ExecuteScriptAsync(
     @"var oReq = new XMLHttpRequest();
     oReq.addEventListener(""load"", reqListener);
-    oReq.open(""GET\"", ""custom-scheme:example-data.json"");
+    oReq.open(""GET\"", ""custom-scheme://domain/example-data.json"");
     oReq.send();");
 // The following XHR will fail because *.example.com is in the not allowed
 // origin list of custom-scheme2. The WebResourceRequested event will not be
@@ -164,8 +163,8 @@ if (options.As(&options3) == S_OK) {
           L"custom-scheme",
           TRUE /* treatAsSecure*/,
           1,
-          FALSE /* hasAuthorityComponent */,
-          allowedOrigins));
+          allowedOrigins,
+          TRUE /* hasAuthorityComponent */));
   schemeRegistrations.push_back(
     Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(
           L"custom-scheme-not-in-allowed-origins-list",
@@ -249,7 +248,7 @@ CHECK_FAILURE(m_webView->Navigate(L"https://www.example.com"));
 CHECK_FAILURE(m_webView->ExecuteScript(
                   L"var oReq = new XMLHttpRequest();"
                   L"oReq.addEventListener(\"load\", reqListener);"
-                  L"oReq.open(\"GET\", \"custom-scheme:example-data.json\");"
+                  L"oReq.open(\"GET\", \"custom-scheme://domain/example-data.json\");"
                   L"oReq.send();",
                   Callback<ICoreWebView2ExecuteScriptCompletedHandler>(
                     [](HRESULT error, PCWSTR result) -> HRESULT {
@@ -283,7 +282,8 @@ CHECK_FAILURE(m_webView->ExecuteScript(
 // is created, the registrations are valid and immutable throughout the
 // lifetime of the associated WebView2s' browser process and any WebView2
 // environments sharing the browser process must be created with identical
-// custom scheme registrations, otherwise the environment creation will fail.
+// custom scheme registrations (order does not matter), otherwise the
+// environment creation will fail.
 // If there are multiple entries for the same scheme in the registrations
 // list, the environment creation will also fail.
 // The URIs of registered custom schemes will be treated similar to http URIs

--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -306,7 +306,6 @@ CHECK_FAILURE(m_webView->ExecuteScript(
 // event handler to allow CORS requests.
 [uuid(d60ac92c-37a6-4b26-a39e-95cfe59047bb), object, pointer_default(unique)]
 interface ICoreWebView2CustomSchemeRegistration : IUnknown {
-  
   // The name of the custom scheme to register.
   [propget] HRESULT SchemeName([out, retval] LPCWSTR* schemeName);
   [propput] HRESULT SchemeName([in] LPCWSTR value);
@@ -324,7 +323,7 @@ interface ICoreWebView2CustomSchemeRegistration : IUnknown {
   // Except origins with this same custom scheme, which are always
   // allowed, the origin of any request (requests that have the
   // [Origin header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin))
-  // to the custom scheme URL needs to be in this list. No-origin requests
+  // to the custom scheme URI needs to be in this list. No-origin requests
   // are requests that do not have an Origin header, such as link
   // navigations, embedded images and are always allowed.
   // Note that cross-origin restrictions still apply.
@@ -347,22 +346,26 @@ interface ICoreWebView2CustomSchemeRegistration : IUnknown {
     [in] UINT32 allowedOriginsCount,
     [in] LPCWSTR* allowedOrigins);
 
-  // Set this to `true` if the URLs with this custom scheme will have an
+  // Set this to `true` if the URIs with this custom scheme will have an
   // authority component (a host for custom schemes).
-  // For example, if you have a URI of the following form you should set the `HasAuthorityComponent` value as listed.
-  //     custom-scheme-without-authority:path - Set to `talse`
-  // When this is set to `true`, the URLs with this scheme will be
+  // For example, if you have a URI of the following form you should set the
+  // `HasAuthorityComponent` value as listed.
+  // | URI | Recommended HasAuthorityComponent value |
+  // | -- | -- |
+  // | ` custom-scheme-with-authority://host/path` | `true` |
+  // | `custom-scheme-without-authority:path` | `false` |
+  // When this is set to `true`, the URIs with this scheme will be
   // interpreted as having a
-  // [scheme and host](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-tuple) 
-  // origin similar to an http URL. Note that the port and user
+  // [scheme and host](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-tuple)
+  // origin similar to an http URI. Note that the port and user
   // information are never included in the computation of origins for
-  // custom schemes. If you set `HasAuthorityComponent` to `true` and 
-  // use a URL with this scheme that does not have
-  // an authority component, the behavior of such URLs will be undefined.
-  // This property is `false` by default. 
-  // If this is set to `false`, URLs with this scheme will have an
+  // custom schemes. If you set `HasAuthorityComponent` to `true` and
+  // use a URI with this scheme that does not have
+  // an authority component, the behavior of such URIs will be undefined.
+  // This property is `false` by default.
+  // If this is set to `false`, URIs with this scheme will have an
   // [opaque origin](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque)
-  // similar to a data URL. 
+  // similar to a data URI.
   [propget] HRESULT HasAuthorityComponent([out, retval] BOOL* hasAuthorityComponent);
   // Get has authority component
   [propput] HRESULT HasAuthorityComponent([in] BOOL  hasAuthorityComponent);
@@ -434,7 +437,7 @@ namespace Microsoft.Web.WebView2.Core
         // Except origins with this same custom scheme, which are always
         // allowed, the origin of any request (requests that have the
         // [Origin header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin))
-        // to the custom scheme URL needs to be in this list. No-origin requests
+        // to the custom scheme URI needs to be in this list. No-origin requests
         // are requests that do not have an Origin header, such as link
         // navigations, embedded images and are always allowed.
         // Note that cross-origin restrictions still apply.
@@ -449,22 +452,26 @@ namespace Microsoft.Web.WebView2.Core
         // For example, "http://*.example.com:80".
         IVector<String> AllowedOrigins { get; } = {};
 
-        // Set this to `True` if the URLs with this custom scheme will have an
+        // Set this to `true` if the URIs with this custom scheme will have an
         // authority component (a host for custom schemes).
-        // eg: custom-scheme-with-authority://host/path - Set to `True`
-        //     custom-scheme-without-authority:path - Set to `False`
-        // When this is set to `True`, the URLs with this scheme will be
-        // interpreted as they have a
-        // [scheme and host](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-tuple) 
-        // origin similar to an http URL. Note that the port and user
+        // For example, if you have a URI of the following form you should set the
+        // `HasAuthorityComponent` value as listed.
+        // | URI | Recommended HasAuthorityComponent value |
+        // | -- | -- |
+        // | ` custom-scheme-with-authority://host/path` | `true` |
+        // | `custom-scheme-without-authority:path` | `false` |
+        // When this is set to `true`, the URIs with this scheme will be
+        // interpreted as having a
+        // [scheme and host](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-tuple)
+        // origin similar to an http URI. Note that the port and user
         // information are never included in the computation of origins for
-        // custom schemes. If you set `HasAuthorityComponent` to `True` and 
-        // use a URL with this scheme that does not have
-        // an authority component, the behavior of such URLs will be undefined.
-        // `False` by default. 
-        // If this is set to `False`, URLs with this scheme will have an
+        // custom schemes. If you set `HasAuthorityComponent` to `true` and
+        // use a URI with this scheme that does not have
+        // an authority component, the behavior of such URIs will be undefined.
+        // This property is `false` by default.
+        // If this is set to `false`, URIs with this scheme will have an
         // [opaque origin](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque)
-        // similar to a data URL. 
+        // similar to a data URI.
         Boolean HasAuthorityComponent {get; set; } = false;
     }
 

--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -164,12 +164,14 @@ if (options.As(&options3) == S_OK) {
           L"custom-scheme",
           TRUE /* treatAsSecure*/,
           1,
+          FALSE /* hasAuthorityComponent */,
           allowedOrigins));
   schemeRegistrations.push_back(
     Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(
           L"custom-scheme-not-in-allowed-origins-list",
           TRUE /* treatAsSecure*/,
-          nullptr));
+          nullptr,
+          FALSE /* hasAuthorityComponent */));
   CHECK_FAILURE(options3->SetCustomSchemeRegistrations(
     schemeRegistrations.size(), schemeRegistrations.data()));
 }
@@ -434,6 +436,12 @@ namespace Microsoft.Web.WebView2.Core
         // [AddWebResourceRequestedFilter API](https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.addwebresourcerequestedfilter).
         // For example, "http://*.example.com:80".
         IVector<String> AllowedOrigins { get; } = {};
+
+        // Whether the scheme has an authority component.
+        // eg: custom-scheme-with-authority://authority/path
+        //     custom-scheme-without-authority:path
+        // `False` by default
+        Boolean HasAuthorityComponent {get; set; } = false;
     }
 
     runtimeclass CoreWebView2EnvironmentOptions

--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -346,26 +346,36 @@ interface ICoreWebView2CustomSchemeRegistration : IUnknown {
     [in] UINT32 allowedOriginsCount,
     [in] LPCWSTR* allowedOrigins);
 
-  // Set this to `true` if the URIs with this custom scheme will have an
-  // authority component (a host for custom schemes).
-  // For example, if you have a URI of the following form you should set the
+  // Set this property to `true` if the URIs with this custom
+  // scheme will have an authority component (a host for custom schemes).
+  // Specifically, if you have a URI of the following form you should set the
   // `HasAuthorityComponent` value as listed.
   // | URI | Recommended HasAuthorityComponent value |
   // | -- | -- |
   // | ` custom-scheme-with-authority://host/path` | `true` |
   // | `custom-scheme-without-authority:path` | `false` |
-  // When this is set to `true`, the URIs with this scheme will be
+  // When this property is set to `true`, the URIs with this scheme will be
   // interpreted as having a
   // [scheme and host](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-tuple)
   // origin similar to an http URI. Note that the port and user
   // information are never included in the computation of origins for
-  // custom schemes. If you set `HasAuthorityComponent` to `true` and
-  // use a URI with this scheme that does not have
-  // an authority component, the behavior of such URIs will be undefined.
-  // This property is `false` by default.
-  // If this is set to `false`, URIs with this scheme will have an
+  // custom schemes.
+  // If this property is set to `false`, URIs with this scheme will have an
   // [opaque origin](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque)
   // similar to a data URI.
+  // This property is `false` by default.
+  //
+  // Note: For custom schemes registered as having authority component,
+  // navigations to URIs without authority of such custom schemes will fail.
+  // However, if the content inside WebView2 references
+  // a subresource with a URI that does not have
+  // an authority component, but of a custom scheme that is registered as
+  // having authority component, the URI will be interpreted as a relative path
+  // as specified in [RFC3986](https://www.rfc-editor.org/rfc/rfc3986).
+  // For example, custom-scheme-with-authority:path will be interpreted
+  // as custom-scheme-with-authority://host/path
+  // However, this behavior cannot be guaranteed to remain in future
+  // releases so it is recommended not to rely on this behavior.
   [propget] HRESULT HasAuthorityComponent([out, retval] BOOL* hasAuthorityComponent);
   // Get has authority component
   [propput] HRESULT HasAuthorityComponent([in] BOOL  hasAuthorityComponent);
@@ -452,26 +462,36 @@ namespace Microsoft.Web.WebView2.Core
         // For example, "http://*.example.com:80".
         IVector<String> AllowedOrigins { get; } = {};
 
-        // Set this to `true` if the URIs with this custom scheme will have an
-        // authority component (a host for custom schemes).
-        // For example, if you have a URI of the following form you should set the
+        // Set this property to `true` if the URIs with this custom
+        // scheme will have an authority component (a host for custom schemes).
+        // Specifically, if you have a URI of the following form you should set the
         // `HasAuthorityComponent` value as listed.
         // | URI | Recommended HasAuthorityComponent value |
         // | -- | -- |
         // | ` custom-scheme-with-authority://host/path` | `true` |
         // | `custom-scheme-without-authority:path` | `false` |
-        // When this is set to `true`, the URIs with this scheme will be
+        // When this property is set to `true`, the URIs with this scheme will be
         // interpreted as having a
         // [scheme and host](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-tuple)
         // origin similar to an http URI. Note that the port and user
         // information are never included in the computation of origins for
-        // custom schemes. If you set `HasAuthorityComponent` to `true` and
-        // use a URI with this scheme that does not have
-        // an authority component, the behavior of such URIs will be undefined.
-        // This property is `false` by default.
-        // If this is set to `false`, URIs with this scheme will have an
+        // custom schemes.
+        // If this property is set to `false`, URIs with this scheme will have an
         // [opaque origin](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque)
         // similar to a data URI.
+        // This property is `false` by default.
+        //
+        // Note: For custom schemes registered as having authority component,
+        // navigations to URIs without authority of such custom schemes will fail.
+        // However, if the content inside WebView2 references
+        // a subresource with a URI that does not have
+        // an authority component, but of a custom scheme that is registered as
+        // having authority component, the URI will be interpreted as a relative path
+        // as specified in [RFC3986](https://www.rfc-editor.org/rfc/rfc3986).
+        // For example, custom-scheme-with-authority:path will be interpreted
+        // as custom-scheme-with-authority://host/path
+        // However, this behavior cannot be guaranteed to remain in future
+        // releases so it is recommended not to rely on this behavior.
         Boolean HasAuthorityComponent {get; set; } = false;
     }
 

--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -70,12 +70,14 @@ options.CustomSchemeRegistrations.Add(
   new CoreWebView2CustomSchemeRegistration(customScheme)
   {
     TreatAsSecure = true,
-    AllowedOrigins = { "https://*.example.com" }
+    AllowedOrigins = { "https://*.example.com" },
+    HasAuthorityComponent = true
   });
 options.CustomSchemeRegistrations.Add(
   new CoreWebView2CustomSchemeRegistration(customSchemeNotInAllowedOrigins)
   {
-    TreatAsSecure = true
+    TreatAsSecure = true,
+    HasAuthorityComponent = true
   });
 
 // Custom scheme registrations are validated here. In case invalid array is
@@ -286,14 +288,14 @@ interface ICoreWebView2CustomSchemeRegistration : IUnknown {
   // list, the environment creation will also fail.
   // The URIs of registered custom schemes will be treated similar to http URIs
   // for their origins.
-  // They will have tuple origins for URIs with host and opaque origins for
-  // URIs without host as specified in
+  // They will have tuple origins for URIs with authority component and opaque origins for
+  // URIs without authority component as specified in
   /// [7.5 Origin - HTML Living Standard](https://html.spec.whatwg.org/multipage/origin.html)
   // Example:
-  // custom-scheme-with-host://hostname/path/to/resource has origin of
-  // custom-scheme-with-host://hostname
-  // custom-scheme-without-host:path/to/resource has origin of
-  // custom-scheme-without-host:path/to/resource
+  // custom-scheme-with-authority://hostname/path/to/resource has origin of
+  // custom-scheme-with-authority://hostname
+  // custom-scheme-without-authority:path/to/resource has origin of
+  // custom-scheme-without-authority:path/to/resource
   // For WebResourceRequested event, the cases of request URIs and filter URIs
   // with custom schemes will be normalized according to generic URI syntax
   // rules. Any non-ASCII characters will be preserved.
@@ -310,6 +312,7 @@ interface ICoreWebView2CustomSchemeRegistration : IUnknown {
   // Whether the sites with this scheme will be treated as a
   // [Secure Context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)
   // like a HTTPS site.
+  // `false` by default.
   [propget] HRESULT TreatAsSecure([out, retval] BOOL* treatAsSecure);
   // Set if the scheme will be treated as a Secure Context.
   [propput] HRESULT TreatAsSecure([in] BOOL value);
@@ -341,6 +344,14 @@ interface ICoreWebView2CustomSchemeRegistration : IUnknown {
   HRESULT SetAllowedOrigins(
     [in] UINT32 allowedOriginsCount,
     [in] LPCWSTR* allowedOrigins);
+
+  // Whether the scheme has an authority component.
+  // eg: custom-scheme-with-authority://authority/path
+  //     custom-scheme-without-authority:path
+  // `False` by default
+  [propget] HRESULT HasAuthorityComponent([out, retval] BOOL* hasAuthorityComponent);
+  // Get has authority component
+  [propput] HRESULT HasAuthorityComponent([in] BOOL  hasAuthorityComponent);
 }
 
 // This is the ICoreWebView2EnvironmentOptions3 interface

--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -359,7 +359,7 @@ interface ICoreWebView2CustomSchemeRegistration : IUnknown {
   // custom schemes. If you set `HasAuthorityComponent` to `true` and 
   // use a URL with this scheme that does not have
   // an authority component, the behavior of such URLs will be undefined.
-  // `false` by default. 
+  // This property is `false` by default. 
   // If this is set to `false`, URLs with this scheme will have an
   // [opaque origin](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque)
   // similar to a data URL. 

--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -352,7 +352,7 @@ interface ICoreWebView2CustomSchemeRegistration : IUnknown {
   // For example, if you have a URI of the following form you should set the `HasAuthorityComponent` value as listed.
   //     custom-scheme-without-authority:path - Set to `talse`
   // When this is set to `true`, the URLs with this scheme will be
-  // interpreted as they have a
+  // interpreted as having a
   // [scheme and host](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-tuple) 
   // origin similar to an http URL. Note that the port and user
   // information are never included in the computation of origins for

--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -161,13 +161,13 @@ if (options.As(&options3) == S_OK) {
   schemeRegistrations.push_back(
     Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(
           L"custom-scheme"));
-  schemeRegistrations.back()->put_HasAuthorityComponent(true);
-  schemeRegistrations.back()->put_TreatAsSecure(true);
+  schemeRegistrations.back()->put_HasAuthorityComponent(TRUE);
+  schemeRegistrations.back()->put_TreatAsSecure(TRUE);
   schemeRegistrations.back()->SetAllowedOrigins(1, allowedOrigins);
   schemeRegistrations.push_back(
     Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(
           L"custom-scheme-not-in-allowed-origins-list"));
-  schemeRegistrations.back()->put_TreatAsSecure(true);
+  schemeRegistrations.back()->put_TreatAsSecure(TRUE);
   CHECK_FAILURE(options3->SetCustomSchemeRegistrations(
     schemeRegistrations.size(), schemeRegistrations.data()));
 }

--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -160,17 +160,14 @@ if (options.As(&options3) == S_OK) {
   const WCHAR* allowedOrigins[1] = {L"https://*.example.com"};
   schemeRegistrations.push_back(
     Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(
-          L"custom-scheme",
-          TRUE /* treatAsSecure*/,
-          1,
-          allowedOrigins,
-          TRUE /* hasAuthorityComponent */));
+          L"custom-scheme"));
+  schemeRegistrations.back()->put_HasAuthorityComponent(true);
+  schemeRegistrations.back()->put_TreatAsSecure(true);
+  schemeRegistrations.back()->SetAllowedOrigins(1, allowedOrigins);
   schemeRegistrations.push_back(
     Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(
-          L"custom-scheme-not-in-allowed-origins-list",
-          TRUE /* treatAsSecure*/,
-          nullptr,
-          FALSE /* hasAuthorityComponent */));
+          L"custom-scheme-not-in-allowed-origins-list"));
+  schemeRegistrations.back()->put_TreatAsSecure(true);
   CHECK_FAILURE(options3->SetCustomSchemeRegistrations(
     schemeRegistrations.size(), schemeRegistrations.data()));
 }

--- a/specs/WebResourceRequested-CustomScheme.md
+++ b/specs/WebResourceRequested-CustomScheme.md
@@ -349,7 +349,7 @@ interface ICoreWebView2CustomSchemeRegistration : IUnknown {
 
   // Set this to `true` if the URLs with this custom scheme will have an
   // authority component (a host for custom schemes).
-  // eg: custom-scheme-with-authority://host/path - Set to `true`
+  // For example, if you have a URI of the following form you should set the `HasAuthorityComponent` value as listed.
   //     custom-scheme-without-authority:path - Set to `talse`
   // When this is set to `true`, the URLs with this scheme will be
   // interpreted as they have a


### PR DESCRIPTION
Add the authority component flag to custom scheme registration as this needs to be known up front for registration.