### PR TITLE
Add API:CoreWebView2Profile.Delete

### DIFF
--- a/specs/ExtendedProcessFailed.md
+++ b/specs/ExtendedProcessFailed.md
@@ -66,6 +66,7 @@ std::wstring ProcessComponent::ProcessFailedReasonToString(
         REASON_ENTRY(COREWEBVIEW2_PROCESS_FAILED_REASON_CRASHED);
         REASON_ENTRY(COREWEBVIEW2_PROCESS_FAILED_REASON_LAUNCH_FAILED);
         REASON_ENTRY(COREWEBVIEW2_PROCESS_FAILED_REASON_OUT_OF_MEMORY);
+        REASON_ENTRY(COREWEBVIEW2_PROCESS_FAILED_REASON_PROFILE_DELETED);
 
 #undef REASON_ENTRY
     }
@@ -544,6 +545,9 @@ typedef enum COREWEBVIEW2_PROCESS_FAILED_REASON {
 
   /// The process died due to running out of memory.
   COREWEBVIEW2_PROCESS_FAILED_REASON_OUT_OF_MEMORY,
+
+  /// The process exited because its corresponding profile was deleted.
+  COREWEBVIEW2_PROCESS_FAILED_REASON_PROFILE_DELETED,
 } COREWEBVIEW2_PROCESS_FAILED_REASON;
 
 /// A continuation of `ICoreWebView2ProcessFailedEventArgs` interface.

--- a/specs/MultiProfile.md
+++ b/specs/MultiProfile.md
@@ -165,6 +165,28 @@ void ScenarioCookieManagement::DeleteAllCookies()
     CHECK_FAILURE(m_cookieManager->DeleteAllCookies();
 }
 ```
+
+### Delete profile
+
+```cpp
+HRESULT AppWindow::DeleteProfile(ICoreWebView2Controller* controller)
+{
+    wil::com_ptr<ICoreWebView2> coreWebView2;
+    CHECK_FAILURE(controller->get_CoreWebView2(&coreWebView2));
+    auto webview7 = coreWebView2.try_query<ICoreWebView2_7>();
+    if (webview7)
+    {
+        wil::com_ptr<ICoreWebView2Profile> profile;
+        CHECK_FAILURE(webview7->get_Profile(&profile));
+        auto profile2 = profile.try_query<ICoreWebView2StagingProfile4>;
+        if (profile2)
+        {
+            CHECK_FAILURE(profile2->Delete());
+        }
+    }
+}
+```
+
 ## .NET and WinRT
 
 ### Create WebView2 with a specific profile, then access the profile property of WebView2
@@ -226,6 +248,17 @@ void DeleteAllCookies()
 }
 ```
 
+```csharp
+public DeleteProfile(CoreWebView2Controller controller)
+{
+    // Get the profile object.
+    CoreWebView2Profile profile = controller.CoreWebView2.Profile;
+    
+    // Delete current profile.
+    profile.Delete();
+}
+```
+
 # API Details
 
 ## Win32 C++
@@ -236,6 +269,7 @@ interface ICoreWebView2Environment5;
 interface ICoreWebView2_7;
 interface ICoreWebView2Profile;
 interface ICoreWebView2Profile2;
+interface ICoreWebView2Profile3;
 
 /// This interface is used to manage profile options that created by 'CreateCoreWebView2ControllerOptions'.
 [uuid(C2669A3A-03A9-45E9-97EA-03CD55E5DC03), object, pointer_default(unique)]
@@ -328,6 +362,18 @@ interface ICoreWebView2Profile2 : ICoreWebView2Profile {
   /// See ICoreWebView2CookieManager.
   [propget] HRESULT CookieManager([out, retval] ICoreWebView2CookieManager** cookieManager);
 }
+
+[uuid(1c1ae2cc-d5c2-ffe3-d3e7-7857035d23b7), object, pointer_default(unique)]
+interface ICoreWebView2Profile3 : ICoreWebView2Profile2 {
+  /// All webviews on this profile will be closed, and the profile will be marked for deletion.
+  /// After the Delete() call completes, The render process of webviews on this profile will
+  /// asynchronously exit with the reason:`COREWEBVIEW2_PROCESS_FAILED_REASON_PROFILE_DELETED`.
+  /// See 'COREWEBVIEW2_PROCESS_FAILED_REASON::COREWEBVIEW2_PROCESS_FAILED_REASON_PROFILE_DELETED'
+  /// for more details. The profile directory on disk will be actually deleted when the browser
+  /// process exits. Profile creation will fail if you create a new profile with the same name
+  /// as a profile that is being deleted.
+  HRESULT Delete(); 
+}
 ```
 
 ## .NET and WinRT
@@ -379,6 +425,12 @@ namespace Microsoft.Web.WebView2.Core
         String ProfilePath { get; };
 
         CoreWebView2CookieManager CookieManager { get; };
+        
+        [interface_name("Microsoft.Web.WebView2.Core.ICoreWebView2Profile3")]
+        {
+            // ICoreWebView2Profile3 members
+            void Delete();
+        }
     }
 }
 ```


### PR DESCRIPTION
Add Api:CoreWebView2Profile.Delete:
1. The user call this Delete API, the API send a MOJOM message to the browser process.
2. The browser process calls API: profile_manager()->MaybeScheduleProfileForDeletion() to make the logic same as Edge: 
     - Mark current profile as "schedule for deleting" and will be truly deleted at thread exit. This makes the Delete API do not 
       need to wait for the local file to be deleted. So, the Delete Api could be treated as synchronous.
     - Close all WV2 under current profile.
3. Add a new Enum's value WEBVIEW2_PROCESS_FAILED_REASON_PROFILE_DELETED which indicate the render process 
    exited due to the related profile is deleted.
4. It will be failure when try to create a "schedule for deleting" profile, the behavior is same as Edge.

So, since the API is synchronous, it does not need a call-back for the caller.
The Delete API will not try to release the client's profile class and WV2 class, but them should not be used any more for the user after Delete API is called, 