### PR TITLE
add issue opened workflow

### DIFF
--- a/.github/workflows/issueOpened.yml
+++ b/.github/workflows/issueOpened.yml
@@ -1,0 +1,27 @@
+name: get security issue by title and body
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    name: get security issue by title and body
+    steps: 
+    - name: filter issue by keyword and send email
+      id: script
+      uses: ElyssaJyu/GH-Auto-Digest-Bot@main
+      with: 
+        email_password: ${{ secrets.EMAIL_PASSWORD }}
+        email_username: 'autodigectbot@outlook.com'
+    - name: need send to teams
+      if: ${{ steps.script.outputs.need_attention == 'true'}}
+      uses: plantree/github-actions-issue-notify-teams@main
+      with:
+          type: new-issue
+          message: ${{ steps.script.outputs.issue_info}}
+          webhook: ${{ secrets.WEBHOOK }}
+    - name: do not need send
+      if: ${{ steps.script.outputs.need_attention == 'false'}}
+      run: echo '${{ github.event.issue.html_url }}'


### PR DESCRIPTION
GH Auto-Digest Bot can send alarm email for new high priority issues such as privacy/data security/etc.
Steps1: ElyssaJyu/GH-Auto-Digest-Bot@main
Check the opened issue title and body keywords to determine Whether it has a high priority. If the issue is a high priority issue, will send an email to default email list. Now, the email send address is a temp address, **will modify when get a Microsoft bot address.**
Steps2: plantree/github-actions-issue-notify-teams@main
If the issue is a high priority issue, will send a message to a team's channel.
**TODO:**
And there are two secrets (WEBHOOK, EMAIL_PASSWORD) need to add GitHub secrets environment.
