### PR TITLE
Add new workflow of daily issue summary

### DIFF
--- a/.github/workflows/dailySummary.yml
+++ b/.github/workflows/dailySummary.yml
@@ -11,5 +11,9 @@ jobs:
     name: get summary
     steps:
     - uses: shangminx/Auto-Digest@main
-      with: 
+      id: getsummary
+    - uses: plantree/github-actions-issue-notify-teams@main
+      with:
+        type: daily-report
+        message: ${{ steps.getsummary.outputs.dailysummary }}
         webhook: ${{ secrets.WEBHOOK }}

--- a/.github/workflows/dailySummary.yml
+++ b/.github/workflows/dailySummary.yml
@@ -1,0 +1,15 @@
+name: get issue summary of yesterday
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 1 * * *'
+  
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    name: get summary
+    steps:
+    - uses: shangminx/Auto-Digest@main
+      with: 
+        webhook: ${{ secrets.WEBHOOK }}


### PR DESCRIPTION
shangminx/Auto-Digest@main is an action that can make summary of daily issues. And it will send summary to teams channel **Webview .NET Notification**.    This action uses a python script with REST API call to fetch issues in json format. And fetch some useful fields. Then use plantree/github-actions-issue-notify-teams@main for sending messages.   This action will schedule at UTC 1:00 every day.

TODO:
one secret **WEBHOOK** need to add GitHub secrets environment.