### PR TITLE
Send email for daily issue summary

### DIFF
--- a/.github/workflows/dailySummary.yml
+++ b/.github/workflows/dailySummary.yml
@@ -12,6 +12,13 @@ jobs:
     steps:
     - uses: shangminx/Auto-Digest@main
       id: getsummary
+    - uses: shangminx/Auto-Digest/sendEmail@main
+      id: sendEmail
+      with: 
+        email_password: ${{ secrets.EMAIL_PASSWORD }}
+        sender_email:  ${{secrets.SENDER_EMAIL}}
+        recipient_email: ${{secrets.RECIPIENT_EMAIL}}
+        report_data: ${{ steps.getsummary.outputs.dailysummary }}
     - uses: plantree/github-actions-issue-notify-teams@main
       with:
         type: daily-report


### PR DESCRIPTION
The daily issue summary was only sent to teams previously. This PR make it able to send to email.