### PR TITLE
Remove edit from regexCommenter

### DIFF
--- a/.github/workflows/regexCommenter.yml
+++ b/.github/workflows/regexCommenter.yml
@@ -2,7 +2,7 @@ name: "Auto comment on issues on regex match"
 
 on:
   issues:
-    types: [opened, edited]
+    types: [opened]
 
 jobs:
     auto-comment:


### PR DESCRIPTION
Remove edited trigger, because the track label directly edits the body, so it retriggers the workflow.