### PR TITLE
Add workflow to tag low priority items

### DIFF
--- a/.github/workflows/tagPriorityLow.yml
+++ b/.github/workflows/tagPriorityLow.yml
@@ -17,7 +17,7 @@ jobs:
         - uses: actions/github-script@v7
           env:
             ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'
-            query_id: '${{ secrets.ADO_LOW_PRIORITY_QUERY_ID }}'
+            query_id: '6777cf01-7065-42ca-99ca-ba0d7b77d8fd'
           with:
             script: |
               const azdev = require('azure-devops-node-api')

--- a/.github/workflows/tagPriorityLow.yml
+++ b/.github/workflows/tagPriorityLow.yml
@@ -17,7 +17,7 @@ jobs:
         - uses: actions/github-script@v7
           env:
             ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'
-            query_id: '${{ secrets.ADO_QUERY_ID }}'
+            query_id: '${{ secrets.ADO_LOW_PRIORITY_QUERY_ID }}'
           with:
             script: |
               const azdev = require('azure-devops-node-api')

--- a/.github/workflows/tagPriorityLow.yml
+++ b/.github/workflows/tagPriorityLow.yml
@@ -1,4 +1,4 @@
-name: tag priority-low items
+name: tag low priority issues
 
 on: 
   workflow_dispatch:
@@ -7,7 +7,7 @@ permissions:
     issues: write
 
 jobs:
-    update-low-priority-items:
+    tag-low-priority-issues:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/setup-node@v4

--- a/.github/workflows/tagPriorityLow.yml
+++ b/.github/workflows/tagPriorityLow.yml
@@ -1,4 +1,4 @@
-name: update low priority items based on ADO query
+name: tag priority-low items
 
 on: 
   workflow_dispatch:
@@ -78,6 +78,8 @@ jobs:
               ghIssueNumbers.forEach(async (issueNumber) => {
                 await addLowPriorityLabel(issueNumber);
               });
+              
+              core.setOutput('Tagged Issues', ghIssueNumbers.join(','));
 
 
               

--- a/.github/workflows/update-low-priority.yml
+++ b/.github/workflows/update-low-priority.yml
@@ -35,6 +35,6 @@ jobs:
               const queryResult = await adoClient.queryById(process.env.query_id);
               
               for (const workItem of queryResult.workItems) {
-                const workItemDetails = await adoClient.getWorkItem(id=workItem.id, expand='links');
+                const workItemDetails = await adoClient.getWorkItem(workItem.id, null, null, azdev.WorkItemExpand.Links);
                 console.log(workItemDetails);
               }

--- a/.github/workflows/update-low-priority.yml
+++ b/.github/workflows/update-low-priority.yml
@@ -35,7 +35,7 @@ jobs:
               const queryResult = await adoClient.queryById(process.env.query_id);
               
               for (const workItem of queryResult.workItems) {
-                const workItemDetails = await adoClient.getWorkItem(workItem.id, expand:'links');
+                const workItemDetails = await adoClient.getWorkItem(id=workItem.id, expand='links');
                 console.log(workItemDetails.fields['System.Title']);
                 console.log(workItemDetails.fields['System.Links']);
               }

--- a/.github/workflows/update-low-priority.yml
+++ b/.github/workflows/update-low-priority.yml
@@ -36,6 +36,5 @@ jobs:
               
               for (const workItem of queryResult.workItems) {
                 const workItemDetails = await adoClient.getWorkItem(id=workItem.id, expand='links');
-                console.log(workItemDetails.fields['System.Title']);
-                console.log(workItemDetails.fields['System.Links']);
+                console.log(workItemDetails);
               }

--- a/.github/workflows/update-low-priority.yml
+++ b/.github/workflows/update-low-priority.yml
@@ -3,6 +3,10 @@ name: update low priority items based on ADO query
 on: 
   workflow_dispatch:
 
+permissions:
+    issues: write
+    contents: read
+
 jobs:
     update-low-priority-items:
         runs-on: ubuntu-latest
@@ -71,7 +75,7 @@ jobs:
                   labels: ['priority-low']
                 });
               }
-              
+
               ghIssueNumbers.forEach(async (issueNumber) => {
                 await addLowPriorityLabel(issueNumber);
               });

--- a/.github/workflows/update-low-priority.yml
+++ b/.github/workflows/update-low-priority.yml
@@ -35,6 +35,6 @@ jobs:
               const queryResult = await adoClient.queryById(process.env.query_id);
               
               for (const workItem of queryResult.workItems) {
-                const workItemDetails = await adoClient.getWorkItem(workItem.id, null, null, azdev.WorkItemExpand.Links);
+                const workItemDetails = await adoClient.getWorkItem(workItem.id, null, null, 3);
                 console.log(workItemDetails);
               }

--- a/.github/workflows/update-low-priority.yml
+++ b/.github/workflows/update-low-priority.yml
@@ -34,11 +34,14 @@ jobs:
               // Querying Lastest Work Items
               const queryResult = await adoClient.queryById(process.env.query_id);
               
-              // Iterate over work items
+              // Iterate over work items, including relations
+              // https://github.com/microsoft/azure-devops-node-api/blob/master/api/interfaces/WorkItemTrackingInterfaces.ts#L1485
               const workItemsDetails = await adoClient.getWorkItems(queryResult.workItems.map(wi => wi.id), null, null, 1);
               
               // Obtain GitHub Issue Number
               function getGitHubIssueNumber(workItem) {
+
+                // Try using relations
                 const relation = workItem.relations.find(r => r.rel === 'Hyperlink' && r.url.includes('github.com'));
                 if (relation) {
                   const match = relation.url.match(/github.com\/[^/]+\/[^/]+\/issues\/(\d+)/);
@@ -46,11 +49,33 @@ jobs:
                     return match[1];
                   }
                 }
+                
+                // Try using the title, which includes [GitHub #123]
+                const match = workItem.fields['System.Title'].match(/\[GitHub #(\d+)\]/);
+                if (match) {
+                  return match[1];
+                }
+
                 return null;
               }
-            
-              // Map ADO work items to GitHub number
-              const ghIssueNumbers = workItemsDetails.map(wi => getGitHubIssueNumber(wi));
-              console.log(ghIssueNumbers);
+    
+              // Map ADO work items to GitHub number, remove nulls
+              const ghIssueNumbers = workItemsDetails.map(wi => getGitHubIssueNumber(wi)).filter(n => n !== null);
+              
+              // Add priority-low label to GitHub issues
+              const addLowPriorityLabel = async (issueNumber) => {
+                await github.rest.issues.addLabels({
+                  issue_number: issueNumber,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  labels: ['priority-low']
+                });
+              }
+              
+              ghIssueNumbers.forEach(async (issueNumber) => {
+                await addLowPriorityLabel(issueNumber);
+              });
+
+
               
             

--- a/.github/workflows/update-low-priority.yml
+++ b/.github/workflows/update-low-priority.yml
@@ -34,7 +34,11 @@ jobs:
               // Querying Lastest Work Items
               const queryResult = await adoClient.queryById(process.env.query_id);
               
-              for (const workItem of queryResult.workItems) {
-                const workItemDetails = await adoClient.getWorkItem(workItem.id, null, null, 1);
-                console.log(workItemDetails);
+              // Iterate over work items
+              const workItemsDetails = await adoClient.getWorkItems(queryResult.workItems.map(wi => wi.id), null, null, 1);
+              
+              for (relations of workItemsDetails[0]){
+                print(relations.attributes);
               }
+
+            

--- a/.github/workflows/update-low-priority.yml
+++ b/.github/workflows/update-low-priority.yml
@@ -5,7 +5,6 @@ on:
 
 permissions:
     issues: write
-    contents: read
 
 jobs:
     update-low-priority-items:

--- a/.github/workflows/update-low-priority.yml
+++ b/.github/workflows/update-low-priority.yml
@@ -18,7 +18,8 @@ jobs:
           with:
             script: |
               const azdev = require('azure-devops-node-api')
-              
+
+              // Get the ADO client
               try {
                 const orgUrl = "https://dev.azure.com/microsoft";
                 const adoAuthHandler = azdev.getPersonalAccessTokenHandler(process.env.ado_token);
@@ -30,5 +31,10 @@ jobs:
                 return;
               }
               
+              // Querying Lastest Work Items
               const queryResult = await adoClient.queryById(process.env.query_id);
-              console.log(queryResult);
+              
+              for (const workItem of queryResult.workItems) {
+                const workItemDetails = await adoClient.getWorkItem(workItem.id);
+                console.log(workItemDetails.relations);
+              }

--- a/.github/workflows/update-low-priority.yml
+++ b/.github/workflows/update-low-priority.yml
@@ -35,6 +35,6 @@ jobs:
               const queryResult = await adoClient.queryById(process.env.query_id);
               
               for (const workItem of queryResult.workItems) {
-                const workItemDetails = await adoClient.getWorkItem(workItem.id, null, null, 3);
+                const workItemDetails = await adoClient.getWorkItem(workItem.id, null, null, 1);
                 console.log(workItemDetails);
               }

--- a/.github/workflows/update-low-priority.yml
+++ b/.github/workflows/update-low-priority.yml
@@ -7,7 +7,7 @@ jobs:
     update-low-priority-items:
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/setup-node@v3
+        - uses: actions/setup-node@v4
           with:
             node-version: '20.x'
         - run: npm install azure-devops-node-api
@@ -36,5 +36,5 @@ jobs:
               
               for (const workItem of queryResult.workItems) {
                 const workItemDetails = await adoClient.getWorkItem(workItem.id);
-                console.log(workItemDetails.relations);
+                console.log(workItemDetails);
               }

--- a/.github/workflows/update-low-priority.yml
+++ b/.github/workflows/update-low-priority.yml
@@ -35,6 +35,7 @@ jobs:
               const queryResult = await adoClient.queryById(process.env.query_id);
               
               for (const workItem of queryResult.workItems) {
-                const workItemDetails = await adoClient.getWorkItem(workItem.id);
-                console.log(workItemDetails);
+                const workItemDetails = await adoClient.getWorkItem(workItem.id, expand:'links');
+                console.log(workItemDetails.fields['System.Title']);
+                console.log(workItemDetails.fields['System.Links']);
               }

--- a/.github/workflows/update-low-priority.yml
+++ b/.github/workflows/update-low-priority.yml
@@ -37,8 +37,20 @@ jobs:
               // Iterate over work items
               const workItemsDetails = await adoClient.getWorkItems(queryResult.workItems.map(wi => wi.id), null, null, 1);
               
-              for (relations of workItemsDetails[0]){
-                print(relations.attributes);
+              // Obtain GitHub Issue Number
+              function getGitHubIssueNumber(workItem) {
+                const relation = workItem.relations.find(r => r.rel === 'Hyperlink' && r.url.includes('github.com'));
+                if (relation) {
+                  const match = relation.url.match(/github.com\/[^/]+\/[^/]+\/issues\/(\d+)/);
+                  if (match) {
+                    return match[1];
+                  }
+                }
+                return null;
               }
-
+            
+              // Map ADO work items to GitHub number
+              const ghIssueNumbers = workItemsDetails.map(wi => getGitHubIssueNumber(wi));
+              console.log(ghIssueNumbers);
+              
             

--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ This is a place for all developers of the [Microsoft Edge WebView2](https://aka.
 - <span class="label" style="background-color: #008800"> tracked </span> We have acknowledged the issue and are tracking it on our internal backlog. We will consider and investigate them in the near future.
     - For bugs, it means we have reproduced the issue.
     - For feature requests, it means we consider it to be a valid request.
-- <span class="label" style="background-color: #B60205"> regression </span> A behavior that used to work in a previous version of WebView2, but no longer works as expected. We will prioritize these issues higher.
-- <span class="label" style="background-color: #006B75"> priority-low </span> We have considered this issue and we decided that we will not be able to address them in the near future.
-
+- <span class="label" style="background-color: #B60205"> regression </span> A behavior that used to work in a previous version of WebView2, but no longer works as expected. We will prioritize this issue higher.
+- <span class="label" style="background-color: #006B75"> priority-low </span> We have considered this issue and decided that we will not be able to address it in the near future. Developers are welcomed to provide justifications on this issue for us to revisit the prioritization.
 
 ## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+<style>
+    .label {
+        border: none;
+        color: white;
+        padding: 1px 6px;
+        text-align: center;
+        display: inline-block;
+        cursor: pointer;
+        font-size: 11px;
+        border-radius: 12px; /* Add rounded corners */
+    }
+</style>
+
 # Microsoft Edge WebView2
 
 Welcome to Microsoft Edge WebView2 feedback repository.
@@ -20,14 +33,24 @@ This is a place for all developers of the [Microsoft Edge WebView2](https://aka.
 1. [Search for existing open bugs](https://github.com/MicrosoftEdge/WebView2Feedback/issues?q=is%3Aissue+is%3Aopen+label%3Abug) to avoid duplicates.
     1. If you find that your bug is already reported, give it a 👍 reaction, and add a comment with additional details that may help us investigate.
     1. If the issue is not already reported, [open a new issue](https://github.com/MicrosoftEdge/WebView2Feedback/issues/new/choose).
-1. Tracked issues will be labeled with the `tracked` label. If you see this label, we are aware of the issue and tracking it on our internal backlog.
+1. Tracked issues will be labeled with the <span class="label" style="background-color: #008800"> tracked </span> label. If you see this label, we are aware of the issue and tracking it on our internal backlog.
 
 ### 💡 How to request a feature
 
 1. [Search for existing feature request](https://github.com/MicrosoftEdge/WebView2Feedback/issues?q=is%3Aissue+is%3Aopen+label%3A%22feature+request%22) to avoid duplicates.
     1. If you find a similar feature request, give it a 👍 reaction, and provide additional context into how you would use the feature.
     2. If the feature is not already requested, [open a new issue](https://github.com/MicrosoftEdge/WebView2Feedback/issues/new/choose).
-1. Tracked issues will be labeled with the `tracked` label. If you see this label, we are aware of the issue and tracking it on our internal backlog.
+1. Tracked issues will be labeled with the <span class="label" style="background-color: #008800"> tracked </span> label. If you see this label, we are aware of the issue and tracking it on our internal backlog.
+
+
+### What do the labels on the issues mean?
+
+- <span class="label" style="background-color: #008800"> tracked </span> We have acknowledged the issue and are tracking it on our internal backlog. We will consider and investigate them in the near future.
+    - For bugs, it means we have reproduced the issue.
+    - For feature requests, it means we consider it to be a valid request.
+- <span class="label" style="background-color: #B60205"> regression </span> A behavior that used to work in a previous version of WebView2, but no longer works as expected. We will prioritize these issues higher.
+- <span class="label" style="background-color: #006B75"> priority-low </span> We have considered this issue and we decided that we will not be able to address them in the near future.
+
 
 ## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This is a place for all developers of the [Microsoft Edge WebView2](https://aka.
 ### What do the labels on the issues mean?
 
 - <span class="label" style="background-color: #008800"> tracked </span> We have acknowledged the issue and are tracking it on our internal backlog. We will consider and investigate them in the near future.
-    - For bugs, it means we have reproduced the issue.
+    - For bugs, it means we think this is an actual product issue.
     - For feature requests, it means we consider it to be a valid request.
 - <span class="label" style="background-color: #B60205"> regression </span> A behavior that used to work in a previous version of WebView2, but no longer works as expected. We will prioritize this issue higher.
 - <span class="label" style="background-color: #006B75"> priority-low </span> We have considered this issue and decided that we will not be able to address it in the near future. Developers are welcomed to provide justifications on this issue for us to revisit the prioritization.


### PR DESCRIPTION
Part of the effort to be communicate to our 3P partners about work status. We would want to update users about lower priority items that will be unlikely to be addressed in the near future.

This workflow, currently a manually dispatched process, looks at our ADO query, and tags those items as low priority accordingly. We could eventually make this become a scheduled process.
 
This utilizes the following actions / libraries:
- https://github.com/actions/github-script
- https://github.com/microsoft/azure-devops-node-api

Simultaneously, I have added the following information to the readme to describe what the tags mean:
![image](https://github.com/MicrosoftEdge/WebView2Feedback/assets/5773562/24a6189f-49d1-43b0-8896-2f429e84c823)
