### PR TITLE
Fix issues with the tag workflow

### DIFF
--- a/.github/workflows/tagPriorityLow.yml
+++ b/.github/workflows/tagPriorityLow.yml
@@ -66,7 +66,7 @@ jobs:
                 }
                 
                 // Try using the title, which includes [GitHub #123]
-                const match = workItem.fields['System.Title'].match(/\[GitHub #(\d+)\]/);
+                const match = workItem?.fields['System.Title']?.match(/\[GitHub #(\d+)\]/);
                 if (match) {
                   return match[1];
                 }

--- a/.github/workflows/tagPriorityLow.yml
+++ b/.github/workflows/tagPriorityLow.yml
@@ -37,12 +37,25 @@ jobs:
               // Querying Lastest Work Items
               const queryResult = await adoClient.queryById(process.env.query_id);
               
-              // Iterate over work items, including relations
-              // https://github.com/microsoft/azure-devops-node-api/blob/master/api/interfaces/WorkItemTrackingInterfaces.ts#L1485
-              const workItemsDetails = await adoClient.getWorkItems(queryResult.workItems.map(wi => wi.id), null, null, 1);
+              // Work Item IDs
+              const workItemIds = queryResult.workItems.map(wi => wi.id);
+
+              // getWorkItems has a limit of 200, so we need to batch the requests
+              const batchSize = 200;
+              const workItemsDetails = [];
+              
+              for (let i = 0; i < workItemIds.length; i += batchSize) {
+                const batchIds = workItemIds.slice(i, i + batchSize);
+                // Include relations in the response
+                // https://github.com/microsoft/azure-devops-node-api/blob/master/api/interfaces/WorkItemTrackingInterfaces.ts#L1485
+                const batchDetails = await adoClient.getWorkItems(batchIds, null, null, 1);
+                workItemsDetails.push(...batchDetails);
+              }
               
               // Obtain GitHub Issue Number
               function getGitHubIssueNumber(workItem) {
+
+                console.log(workItem);
 
                 // Try using relations
                 const relation = workItem.relations.find(r => r.rel === 'Hyperlink' && r.url.includes('github.com'));

--- a/.github/workflows/tagPriorityLow.yml
+++ b/.github/workflows/tagPriorityLow.yml
@@ -55,10 +55,9 @@ jobs:
               // Obtain GitHub Issue Number
               function getGitHubIssueNumber(workItem) {
 
-                console.log(workItem);
-
                 // Try using relations
-                const relation = workItem.relations.find(r => r.rel === 'Hyperlink' && r.url.includes('github.com'));
+                const relation = workItem?.relations?.find(r => r.rel === 'Hyperlink' && r.url.includes('github.com'));
+
                 if (relation) {
                   const match = relation.url.match(/github.com\/[^/]+\/[^/]+\/issues\/(\d+)/);
                   if (match) {


### PR DESCRIPTION
- Does batch updates, because the endpoint only supports 200 work items at a time
- Use null chaining such that errors won't be thrown, and code proceeds.