### PR TITLE
Add Canary Testing Documentation

### DIFF
--- a/diagnostics/README.md
+++ b/diagnostics/README.md
@@ -7,3 +7,4 @@ This folder contains directions for gathering various detailed diagnostics/logs 
 - [GPU Info](gpu.md): GPU logs include details on the user's GPU and any potential graphics or rendering issues.
 - [Network Logs](network.md): Network logs include the network requests, responses, and details on any errors when loading files.
 - [Code Integrity](code_integrity.md): how to root cause STATUS_INVALID_IMAGE_HASH errors.
+- [Test in Canary](test_canary.md): how to test new WebView2 runtime changes by using Edge Canary.

--- a/diagnostics/test_canary.md
+++ b/diagnostics/test_canary.md
@@ -8,6 +8,6 @@ The latest runtime changes are first shipped in the WebView2 runtime in the Edge
 3. Restart your application, and you should be able to see that your application picks up the latest runtime. 
 
 To remove the registry key added, run the following:  
-`REG DELETE HKCU\Software\Policies\Microsoft\Edge\WebView2\ChannelSearchKind`
+`REG DELETE HKCU\Software\Policies\Microsoft\Edge\WebView2\ChannelSearchKind /v <your_app.exe>`
 
 For more information, read the documentation on [Test upcoming APIs and features](https://learn.microsoft.com/en-us/microsoft-edge/webview2/how-to/set-preview-channel)

--- a/diagnostics/test_canary.md
+++ b/diagnostics/test_canary.md
@@ -1,6 +1,6 @@
 # Test Feature in Canary
 
-The latest runtime changes are first shipped in the WebView2 runtime in the Edge Canary Browser. If you would like to test the new changes with your application, here's a suggested way to do so:
+The latest runtime changes are first shipped in the WebView2 runtime in the Edge Canary Browser. If you would like to test the new changes or help us to verify that your issue is fixed with your application, here's a suggested way to do so:
 
 1. Download [Edge Canary](https://www.microsoft.com/en-us/edge/download/insider)
 2. Run the following command in a PowerShell with Administrative Priviledges:  
@@ -10,4 +10,4 @@ The latest runtime changes are first shipped in the WebView2 runtime in the Edge
 To remove the registry key added, run the following:  
 `REG DELETE HKCU\Software\Policies\Microsoft\Edge\WebView2\ChannelSearchKind`
 
-For more information, read the documentation on [Test upcoming APIs and features](https://learn.microsoft.com/en-us/microsoft-edge/webview2/how-to/set-preview-channe)
+For more information, read the documentation on [Test upcoming APIs and features](https://learn.microsoft.com/en-us/microsoft-edge/webview2/how-to/set-preview-channel)

--- a/diagnostics/test_canary.md
+++ b/diagnostics/test_canary.md
@@ -1,0 +1,13 @@
+# Test Feature in Canary
+
+The latest runtime changes are first shipped in the WebView2 runtime in the Edge Canary Browser. If you would like to test the new changes with your application, here's a suggested way to do so:
+
+1. Download [Edge Canary](https://www.microsoft.com/en-us/edge/download/insider)
+2. Run the following command in a PowerShell with Administrative Priviledges:  
+  `REG ADD HKCU\Software\Policies\Microsoft\Edge\WebView2\ChannelSearchKind /v <your_app.exe> /t REG_DWORD /d 1`
+3. Restart your application, and you should be able to see that your application picks up the latest runtime. 
+
+To remove the registry key added, run the following:  
+`REG DELETE HKCU\Software\Policies\Microsoft\Edge\WebView2\ChannelSearchKind`
+
+For more information, read the documentation on [Test upcoming APIs and features](https://learn.microsoft.com/en-us/microsoft-edge/webview2/how-to/set-preview-channe)


### PR DESCRIPTION
- Updates `README.md` with instructions for testing new WebView2 runtime changes using Edge Canary.
- Adds `test_canary.md` detailing the process to test features in Edge Canary, including download steps and registry key setup.

Aims to streamline diagnostics collection and facilitate early testing of WebView2 runtime updates for developers