### PR TITLE
Provide write permission to crashbot

### DIFF
--- a/.github/workflows/regexCommenter.yml
+++ b/.github/workflows/regexCommenter.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+    issues: write
+
 jobs:
     auto-comment:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Write permission to allow github workflow to make comments on issues. Change required due to new security requirement for github workflows