### PR TITLE
Update GitHub Actions workflow permissions and token

### DIFF
--- a/.github/workflows/syncAdo.yml
+++ b/.github/workflows/syncAdo.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  issues: write
 
 jobs:
   alert:
@@ -22,7 +23,7 @@ jobs:
     - name: Sync to ADO
       uses: Navdeep-ss/github-actions-issue-to-work-item@simple-sync-azurecli
       env:
-        github_token: "${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}"
+        github_token: "${{ secrets.GITHUB_TOKEN }}"
       with:
         label: 'tracked'
         ado_organization: 'microsoft'


### PR DESCRIPTION
We were previously using personal access tokens with no expiry in our workflows, but that’s not allowed by the project. It caused an error when trying to update issues:  
**RequestError [HttpError]: The 'Microsoft Open Source' enterprise forbids access via a personal access token (classic) if the token's lifetime is greater than 90 days.**  

To fix this, we switched to using `GITHUB_TOKEN`, which is automatically generated per workflow and has the necessary permissions to read and write issues.