### PR TITLE
Update repo-token to use personal access token

### DIFF
--- a/.github/workflows/regexLabeler.yml
+++ b/.github/workflows/regexLabeler.yml
@@ -16,7 +16,7 @@ jobs:
         configuration-path: .github/labeler.yml
         enable-versioned-regex: 0
         include-title: 1
-        repo-token: ${{ github.token }}
+        repo-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
     - uses: wow-actions/auto-assign@v3
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The default `github.token` (aka `secrets.GITHUB_TOKEN`) doesn’t trigger workflows when used in a GitHub Actio. For example, if you have a workflow that runs when an issue label changes, it won’t fire if the label was added by another workflow using `github.token`. However, a personal access token (PAT) *does* have the necessary permissions to trigger downstream workflows. Since we want our `syncAdo` workflow to run after `issueLabeler` labels a bug, we’re switching to using a PAT.
