### PR TITLE
[Diagnostics] Add Crashpad folder to diagnostic script

### DIFF
--- a/diagnostics/script.md
+++ b/diagnostics/script.md
@@ -27,7 +27,7 @@ The script will collect some registry keys and directory listings, start a WPR t
    - msedge_installer_Temp.log (*optional*)
    - msedge_installer_SystemTemp.log (*optional*)
    - msedge_installer_SystemTemp2.log (*optional*)
-   - Crashpad folder (*optional*, if ExeName or userDataDir provided): Contains crash dumps and metadata to help diagnose application crashes.
+   - Crashpad folder (*optional*, if ExeName or UserDataDir provided): Contains crash dumps and metadata to help diagnose application crashes.
 7. Provide the resulting ZIP file to the WebView2 support team for analysis.
 
 **Optional**


### PR DESCRIPTION
## Summary
Enhanced the WebView2 diagnostic log collection script to automatically locate and include the entire Crashpad folder in the diagnostic ZIP file. This improves crash troubleshooting by capturing all crash reports and metadata in one collection.

## Changes
- **Automatic process detection**: Script now searches for running WebView2 processes to automatically find the user data folder and Crashpad directory
- **Complete Crashpad folder collection**: Recursively includes all Crashpad folder contents (crash reports, watson_metadata, etc.).
- **New parameters**:
   - **ExeName** (optional): Specifies the host application executable name for process filtering
   - **userDataDir** (optional): Manual override for user data directory when automatic detection fails
- **Updated documentation**: Reflected new usage and collected files in script.md
