### PR TITLE
Add SmartScreen as origin feature to TrustedOriginSetting spec

### DIFF
--- a/specs/TrustedOriginSetting.md
+++ b/specs/TrustedOriginSetting.md
@@ -62,6 +62,7 @@ This specification introduces the following interfaces:
 
     - AccentColor 
     - EnhancedSecurityMode
+    - SmartScreen
 
 # Example
 
@@ -88,10 +89,17 @@ void SetOriginFeatures()
         COREWEBVIEW2_ORIGIN_FEATURE_STATE_ENABLED,
         &enhancedSecuritySetting));
 
+    wil::com_ptr<ICoreWebView2StagingOriginFeatureSetting> smartScreenSetting;
+    CHECK_FAILURE(stagingProfile3->CreateOriginFeatureSetting(
+        COREWEBVIEW2_ORIGIN_FEATURE_SMART_SCREEN,
+        COREWEBVIEW2_ORIGIN_FEATURE_STATE_DISABLED,
+        &smartScreenSetting));
+
     // Set features for origin patterns
     ICoreWebView2StagingOriginFeatureSetting* features[] = {
         accentColorSetting.get(),
-        enhancedSecuritySetting.get()
+        enhancedSecuritySetting.get(),
+        smartScreenSetting.get()
     };
 
     LPCWSTR origins[] = { L"https://*.contoso.com" };
@@ -154,6 +162,7 @@ public void SetOriginFeatures()
     {
         { CoreWebView2OriginFeature.AccentColor, CoreWebView2OriginFeatureState.Enabled },
         { CoreWebView2OriginFeature.EnhancedSecurityMode, CoreWebView2OriginFeatureState.Enabled },
+        { CoreWebView2OriginFeature.SmartScreen, CoreWebView2OriginFeatureState.Disabled },
     };
 
     // Set features for origin patterns
@@ -203,6 +212,21 @@ typedef enum COREWEBVIEW2_ORIGIN_FEATURE {
   /// For more information about Enhanced Security Mode, see:
   /// https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/security
   COREWEBVIEW2_ORIGIN_FEATURE_ENHANCED_SECURITY_MODE,
+  /// Specifies SmartScreen reputation check settings for the origin.
+  /// SmartScreen protects users from phishing and malware by checking navigated
+  /// URLs and downloaded files against a cloud-based reputation service.
+  /// By default, SmartScreen is enabled for all origins. Setting this feature to
+  /// `Disabled` for an origin will skip SmartScreen reputation checks for
+  /// navigations and downloads from that origin, effectively allow-listing it.
+  /// 
+  /// This configuration operates within the scope of the global SmartScreen toggle
+  /// controlled by `ICoreWebView2Settings8.IsReputationCheckingRequired`.
+  /// When `IsReputationCheckingRequired` is `false` (SmartScreen globally
+  /// disabled), the SmartScreen check is not active and this
+  /// per-origin configuration has no effect. When `IsReputationCheckingRequired`
+  /// is `true` (the default), this per-origin configuration controls whether
+  /// individual origins are exempt from SmartScreen reputation checks.
+  COREWEBVIEW2_ORIGIN_FEATURE_SMART_SCREEN,
 } COREWEBVIEW2_ORIGIN_FEATURE;
 
 /// Specifies the state of the origin feature.
@@ -234,7 +258,7 @@ interface ICoreWebView2StagingProfile3 : IUnknown {
   /// Configures one or more feature settings for the specified origins. 
   /// 
   /// This method applies feature configurations—such as accent color support, 
-  /// or enhanced security mode—to origins. Origins 
+  /// enhanced security mode, or SmartScreen reputation checking—to origins. Origins 
   /// may be provided as exact origin strings or as wildcard patterns. 
   /// 
   /// The origin pattern can be an exact origin string or a wildcard pattern.
@@ -336,6 +360,7 @@ namespace Microsoft.Web.WebView2.Core
     {
         AccentColor = 0,
         EnhancedSecurityMode = 1,
+        SmartScreen = 2,
     };
 
     runtimeclass CoreWebView2OriginFeatureSetting

--- a/specs/TrustedOriginSetting.md
+++ b/specs/TrustedOriginSetting.md
@@ -219,18 +219,14 @@ typedef enum COREWEBVIEW2_ORIGIN_FEATURE {
   /// `Disabled` for an origin will skip SmartScreen reputation checks for
   /// navigations and downloads from that origin, effectively allow-listing it.
   /// 
-  /// \warning Disabling SmartScreen for an origin removes important security
-  /// protections. Only disable SmartScreen for fully trusted, app-controlled
-  /// origins where the content is known to be safe.
+  /// Warning: Disabling SmartScreen for an origin bypasses phishing and malware
+  /// reputation checks. Only disable for fully trusted, app-controlled origins
+  /// where the content is known to be safe.
   /// 
-  /// This configuration operates within the scope of the per-WebView SmartScreen
-  /// setting controlled by
-  /// [IsReputationCheckingRequired](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isreputationcheckingrequired).
-  /// When `IsReputationCheckingRequired` is `false` (SmartScreen
-  /// disabled), the SmartScreen check is not active and this
-  /// per-origin configuration has no effect. When `IsReputationCheckingRequired`
-  /// is `true` (the default), this per-origin configuration controls whether
-  /// individual origins are exempt from SmartScreen reputation checks.
+  /// This per-origin configuration only takes effect when SmartScreen is
+  /// enabled. If SmartScreen is disabled via
+  /// [IsReputationCheckingRequired](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isreputationcheckingrequired),
+  /// this setting has no effect.
   COREWEBVIEW2_ORIGIN_FEATURE_SMART_SCREEN,
 } COREWEBVIEW2_ORIGIN_FEATURE;
 

--- a/specs/TrustedOriginSetting.md
+++ b/specs/TrustedOriginSetting.md
@@ -219,9 +219,14 @@ typedef enum COREWEBVIEW2_ORIGIN_FEATURE {
   /// `Disabled` for an origin will skip SmartScreen reputation checks for
   /// navigations and downloads from that origin, effectively allow-listing it.
   /// 
-  /// This configuration operates within the scope of the global SmartScreen toggle
-  /// controlled by `ICoreWebView2Settings8.IsReputationCheckingRequired`.
-  /// When `IsReputationCheckingRequired` is `false` (SmartScreen globally
+  /// \warning Disabling SmartScreen for an origin removes important security
+  /// protections. Only disable SmartScreen for fully trusted, app-controlled
+  /// origins where the content is known to be safe.
+  /// 
+  /// This configuration operates within the scope of the per-WebView SmartScreen
+  /// setting controlled by
+  /// [IsReputationCheckingRequired](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isreputationcheckingrequired).
+  /// When `IsReputationCheckingRequired` is `false` (SmartScreen
   /// disabled), the SmartScreen check is not active and this
   /// per-origin configuration has no effect. When `IsReputationCheckingRequired`
   /// is `true` (the default), this per-origin configuration controls whether

--- a/specs/TrustedOriginSetting.md
+++ b/specs/TrustedOriginSetting.md
@@ -62,7 +62,7 @@ This specification introduces the following interfaces:
 
     - AccentColor 
     - EnhancedSecurityMode
-    - SmartScreen
+    - ReputationChecking
 
 # Example
 
@@ -89,17 +89,17 @@ void SetOriginFeatures()
         COREWEBVIEW2_ORIGIN_FEATURE_STATE_ENABLED,
         &enhancedSecuritySetting));
 
-    wil::com_ptr<ICoreWebView2StagingOriginFeatureSetting> smartScreenSetting;
+    wil::com_ptr<ICoreWebView2StagingOriginFeatureSetting> reputationCheckingSetting;
     CHECK_FAILURE(stagingProfile3->CreateOriginFeatureSetting(
-        COREWEBVIEW2_ORIGIN_FEATURE_SMART_SCREEN,
+        COREWEBVIEW2_ORIGIN_FEATURE_REPUTATION_CHECKING,
         COREWEBVIEW2_ORIGIN_FEATURE_STATE_DISABLED,
-        &smartScreenSetting));
+        &reputationCheckingSetting));
 
     // Set features for origin patterns
     ICoreWebView2StagingOriginFeatureSetting* features[] = {
         accentColorSetting.get(),
         enhancedSecuritySetting.get(),
-        smartScreenSetting.get()
+        reputationCheckingSetting.get(),
     };
 
     LPCWSTR origins[] = { L"https://*.contoso.com" };
@@ -162,7 +162,7 @@ public void SetOriginFeatures()
     {
         { CoreWebView2OriginFeature.AccentColor, CoreWebView2OriginFeatureState.Enabled },
         { CoreWebView2OriginFeature.EnhancedSecurityMode, CoreWebView2OriginFeatureState.Enabled },
-        { CoreWebView2OriginFeature.SmartScreen, CoreWebView2OriginFeatureState.Disabled },
+        { CoreWebView2OriginFeature.ReputationChecking, CoreWebView2OriginFeatureState.Disabled },
     };
 
     // Set features for origin patterns
@@ -212,22 +212,19 @@ typedef enum COREWEBVIEW2_ORIGIN_FEATURE {
   /// For more information about Enhanced Security Mode, see:
   /// https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/security
   COREWEBVIEW2_ORIGIN_FEATURE_ENHANCED_SECURITY_MODE,
-  /// Specifies SmartScreen reputation check settings for the origin.
-  /// SmartScreen protects users from phishing and malware by checking navigated
-  /// URLs and downloaded files against a cloud-based reputation service.
-  /// By default, SmartScreen is enabled for all origins. Setting this feature to
-  /// `Disabled` for an origin will skip SmartScreen reputation checks for
-  /// navigations and downloads from that origin, effectively allow-listing it.
+  /// Specifies per-origin reputation checking settings.
+  /// Reputation checking protects users from phishing and malware by checking
+  /// navigated URLs and downloaded files against a cloud-based reputation service.
+  /// Setting this feature to `Disabled` for an origin will skip reputation
+  /// checks for navigations and downloads from that origin, effectively
+  /// allow-listing it. If reputation checking is not configured for an origin,
+  /// the [IsReputationCheckingRequired](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isreputationcheckingrequired)
+  /// setting will apply.
   /// 
-  /// Warning: Disabling SmartScreen for an origin bypasses phishing and malware
-  /// reputation checks. Only disable for fully trusted, app-controlled origins
-  /// where the content is known to be safe.
-  /// 
-  /// This per-origin configuration only takes effect when SmartScreen is
-  /// enabled. If SmartScreen is disabled via
-  /// [IsReputationCheckingRequired](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isreputationcheckingrequired),
-  /// this setting has no effect.
-  COREWEBVIEW2_ORIGIN_FEATURE_SMART_SCREEN,
+  /// Warning: Disabling reputation checking for an origin bypasses phishing and
+  /// malware reputation checks. Only disable for fully trusted, app-controlled
+  /// origins where the content is known to be safe.
+  COREWEBVIEW2_ORIGIN_FEATURE_REPUTATION_CHECKING,
 } COREWEBVIEW2_ORIGIN_FEATURE;
 
 /// Specifies the state of the origin feature.
@@ -258,8 +255,8 @@ interface ICoreWebView2StagingProfile3 : IUnknown {
 
   /// Configures one or more feature settings for the specified origins. 
   /// 
-  /// This method applies feature configurations—such as accent color support, 
-  /// enhanced security mode, or SmartScreen reputation checking—to origins. Origins 
+  /// This method applies feature configurations (such as accent color support, 
+  /// enhanced security mode, or reputation checking) to origins. Origins 
   /// may be provided as exact origin strings or as wildcard patterns. 
   /// 
   /// The origin pattern can be an exact origin string or a wildcard pattern.
@@ -361,7 +358,7 @@ namespace Microsoft.Web.WebView2.Core
     {
         AccentColor = 0,
         EnhancedSecurityMode = 1,
-        SmartScreen = 2,
+        ReputationChecking = 2,
     };
 
     runtimeclass CoreWebView2OriginFeatureSetting


### PR DESCRIPTION
- Add COREWEBVIEW2_ORIGIN_FEATURE_SMART_SCREEN enum with documentation describing per-origin SmartScreen reputation check configuration. 
- Update C++, .NET examples and MIDL3 enum to include SmartScreen.