### PR TITLE
API Review: Shared WebView2 Cluster Environment

### DIFF
--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -48,10 +48,15 @@ such as a sandboxed AppContainer process (for example a UWP app), is not
 supported and the operation fails with `ERROR_NOT_SUPPORTED`.
 
 Unlike `CreateCoreWebView2EnvironmentWithOptions`, you do **not** pass a user data
-folder. The runtime derives the folder from the cluster `Id` through a fixed
-mapping, so every host that uses the same `Id` resolves to the same on-disk layout.
-A cluster occupies its own user data folder namespace: it never joins or collides
-with an environment created by `CreateCoreWebView2EnvironmentWithOptions`.
+folder. The runtime derives the folder from the cluster `Id`, so every host that uses
+the same `Id` resolves to the same on-disk location. The folder is created under a
+per-user cluster root, `%LOCALAPPDATA%\Microsoft\WebView2Clusters\<Id>`, with the
+`Id` as the leaf folder name (this is why the `Id` must be a valid folder name). A
+cluster occupies its own user data folder namespace: folders under this root are
+reachable only through the cluster API. Even if a caller passes a cluster folder path
+explicitly to `CreateCoreWebView2EnvironmentWithOptions`, that call is rejected and
+does not join the cluster, so a cluster never joins or collides with an environment
+created through the ordinary create path.
 
 The **cluster options** are the `ICoreWebView2ClusterEnvironmentOptions` that the
 first host to establish the cluster supplied. They apply to the whole shared browser

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -198,7 +198,7 @@ void AppWindow::CreateSharedEnvironment()
 
     // Step 1 - synchronously ask what options the cluster already uses. This call
     // does not start a browser process. `existing` is null when no cluster is
-    // running for this name, which is an expected result rather than an error.
+    // running for this name.
     wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> existing;
     CHECK_FAILURE(GetCoreWebView2ClusterEnvironmentOptions(kClusterName, &existing));
 
@@ -317,18 +317,29 @@ CoreWebView2ClusterEnvironmentOptions BuildClusterOptions()
 async Task CreateSharedEnvironmentAsync()
 {
     // Step 0 - check that the installed WebView2 Runtime is new enough to support
-    // cluster environments. If it is not, use a private environment.
-    string availableVersion = CoreWebView2Environment.GetAvailableBrowserVersionString();
-    if (availableVersion == null ||
-        CoreWebView2Environment.CompareBrowserVersions(
+    // cluster environments. If it is not, use a private environment. A missing
+    // Runtime throws, the same as CreateAsync.
+    string availableVersion;
+    try
+    {
+        availableVersion = CoreWebView2Environment.GetAvailableBrowserVersionString();
+    }
+    catch (WebView2RuntimeNotFoundException)
+    {
+        UsePrivateEnvironment();
+        return;
+    }
+
+    if (CoreWebView2Environment.CompareBrowserVersions(
             availableVersion, MinClusterRuntimeVersion) < 0)
     {
         UsePrivateEnvironment();
         return;
     }
 
-    // Step 1 - read the cluster's options for this `ClusterName`. This call does not start a
-    // browser process. Returns null when no cluster exists yet.
+    // Step 1 - synchronously ask what options the cluster already uses. This call
+    // does not start a browser process. `existing` is null when no cluster is
+    // running for this name.
     CoreWebView2ClusterEnvironmentOptions existing =
         CoreWebView2Environment.GetClusterEnvironmentOptions(SharedClusterName);
 
@@ -342,10 +353,19 @@ async Task CreateSharedEnvironmentAsync()
     }
     CoreWebView2ClusterEnvironmentOptions options = existing ?? BuildClusterOptions();
 
-    // Step 3 - use the same create operation in either case. The expected outcomes,
-    // including this host not being able to use cluster environments, come back as
-    // Status. Runtime discovery failures, such as no compatible WebView2 Runtime
-    // being installed, throw the same as CreateAsync.
+    // Step 3 - use the same create operation in either case: it establishes or
+    // attaches to a cluster with matching options.
+    await CreateSharedEnvironmentWithOptionsAsync(options);
+}
+
+async Task CreateSharedEnvironmentWithOptionsAsync(
+    CoreWebView2ClusterEnvironmentOptions options, bool allowRetry = true)
+{
+    // The expected outcomes, including this host not being able to use cluster
+    // environments, come back as Status. Failures throw the same as CreateAsync,
+    // whether the operation could not start (for example, no compatible WebView2
+    // Runtime is installed) or started and then failed (for example, the browser
+    // process could not be launched).
     CoreWebView2ClusterEnvironmentCreateResult result =
         await CoreWebView2Environment.CreateOrJoinClusterEnvironmentAsync(options);
 
@@ -357,27 +377,25 @@ async Task CreateSharedEnvironmentAsync()
             break;
 
         case CoreWebView2ClusterEnvironmentStatus.OptionsMismatch:
+        {
             // The live cluster's options differ from the requested options. Re-read
             // the authoritative options and retry once with them; if it still does
-            // not work out, go private. Retrying only once (rather than looping)
-            // bounds the work if the cluster keeps changing.
+            // not work out, go private.
             CoreWebView2ClusterEnvironmentOptions authoritative =
                 CoreWebView2Environment.GetClusterEnvironmentOptions(SharedClusterName);
-            if (authoritative != null && AcceptableForMe(authoritative))
+            if (allowRetry &&
+                authoritative != null &&
+                AcceptableForMe(authoritative))
             {
-                result = await CoreWebView2Environment
-                    .CreateOrJoinClusterEnvironmentAsync(authoritative);
-            }
-
-            if (result.Status == CoreWebView2ClusterEnvironmentStatus.Succeeded)
-            {
-                OnSharedEnvironmentReady(result.Environment);
+                await CreateSharedEnvironmentWithOptionsAsync(
+                    authoritative, allowRetry: false);
             }
             else
             {
                 UsePrivateEnvironment();
             }
             break;
+        }
 
         case CoreWebView2ClusterEnvironmentStatus.NotSupported:
             // This host cannot use cluster environments, for example a sandboxed
@@ -515,8 +533,7 @@ STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
 /// attaching to a cluster. A cluster exists only while its browser process is
 /// running. Returns `S_OK` and the cluster's options when a cluster is running for
 /// that `ClusterName`, or `S_OK` and `nullptr` `options` when no cluster is running for
-/// that `ClusterName`. No cluster for a given `ClusterName` is an expected result rather
-/// than an error, so check `options` for `nullptr` instead of checking for a failing
+/// that `ClusterName`. Check `options` for `nullptr` rather than for a failing
 /// `HRESULT`. Returns `E_INVALIDARG` for an invalid `ClusterName`.
 ///
 /// The returned object is a detached snapshot of the cluster's options at the time

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -364,19 +364,6 @@ namespace Microsoft.Web.WebView2.Core
 
 # Appendix
 
-## Alternatives considered
-
-Two other API shapes were evaluated and rejected in favor of this one.
-
-- **Create / Join role split.** One host `Create`s and pins options; others `Join` by
-  name and get the pinned set back. Cleaner asymmetry, but it has a bootstrap race
-  (two hosts `Join`ing before anyone `Create`s both get `NOT_FOUND`, needing an extra
-  rule). The symmetric model here avoids that because every host runs the same create.
-- **One synchronous getter, nothing else.** Keep today's UDF-based sharing and only add
-  a `Get` so a joiner can look before it leaps. Smallest surface, but no named
-  rendezvous and no lockable "establish" step. This model was chosen because it makes
-  sharing explicit; the getter-only shape remains a smaller-surface fallback.
-
 ## Relationship to existing options
 
 `ICoreWebView2ClusterEnvironmentOptions` is a new type rather than a reuse of

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -401,6 +401,34 @@ void AppWindow::DeleteClusterUserDataFolderOnUninstall()
 }
 ```
 
+The .NET equivalent uses the `UserDataFolder` property and the `BrowserProcessExited`
+event in the same way:
+
+```c#
+// Called during uninstall of a cooperating application.
+void DeleteClusterUserDataFolderOnUninstall()
+{
+    // 1. App-specific check: proceed only if this is the last cooperating
+    //    application, so no other application is still using this cluster.
+    if (OtherClusterAppsStillInstalled(SharedClusterName))
+        return;
+
+    // 2. Read the cluster's user data folder path from the environment this
+    //    application joined.
+    string userDataFolder = m_clusterEnvironment.UserDataFolder;
+
+    // 3. The folder cannot be deleted while the shared browser process is running, so
+    //    delete it once BrowserProcessExited reports that the process has fully exited,
+    //    then release all references to let it exit. This is the same pattern used to
+    //    delete an ordinary user data folder.
+    m_clusterEnvironment.BrowserProcessExited += (sender, args) =>
+    {
+        Directory.Delete(userDataFolder, recursive: true);
+    };
+    m_clusterEnvironment = null;
+}
+```
+
 # API Details
 
 ## Win32 C++
@@ -448,6 +476,24 @@ void AppWindow::DeleteClusterUserDataFolderOnUninstall()
 /// are serialized: the first to establish the cluster fixes its options, and each
 /// later call either attaches (matching options) or reports
 /// `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`.
+///
+/// Only the options on `ICoreWebView2ClusterEnvironmentOptions` participate in the
+/// match. Some options resolve against the host process or machine rather than being a
+/// fixed value; in that case the first host to establish the cluster fixes the effective
+/// behavior for every host that attaches. For example, an empty `Language` resolves to
+/// the first host's OS display language, so a later host with a different OS locale uses
+/// that same language. Cooperating hosts that want a predictable result should set such
+/// options explicitly.
+///
+/// State that is not an option is not part of the match and does not produce
+/// `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`. Loader overrides such as
+/// `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER` are host-determined, and the first host's
+/// resolution governs the cluster. The host process's DPI awareness is likewise not an
+/// option; as when sharing a user data folder through
+/// `CreateCoreWebView2EnvironmentWithOptions`, DPI awareness is negotiated with the
+/// shared browser process when a WebView is created on a window, so a later host whose
+/// DPI awareness is incompatible with the running shared browser can fail when it creates
+/// a WebView rather than here.
 STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
     [in] ICoreWebView2ClusterEnvironmentOptions* options,
     [in] ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler* handler);

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -51,12 +51,13 @@ those hosts agree on out of band. All hosts that establish a cluster with the sa
 `ClusterName` run inside one shared browser process and one on-disk user data folder.
 
 Cluster environments are supported for standard desktop host processes: non-sandboxed,
-non-containerized applications running at medium or high integrity level. Applications
-that cannot create or share the cluster's per-user user data folder are reported with a
-status of `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_NOT_SUPPORTED` rather than as a
-failure of the call. A transient failure to access an otherwise-supported cluster's
-user data folder (for example, an access-denied or sharing violation) is not reported
-that way; it surfaces as an ordinary create failure.
+non-containerized applications running at medium or high integrity level. For an
+application that cannot create or share the cluster's per-user user data folder, the
+outcome is reported with a status of
+`COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_NOT_SUPPORTED` rather than as a failure of the
+call. A transient failure to access an otherwise-supported cluster's user data folder
+(for example, an access-denied or sharing violation) is not reported that way; it
+surfaces as an ordinary create failure.
 
 These entry points exist only in WebView2 Runtime versions that implement them. On an
 older runtime they are unavailable, so a host should feature-detect the API using the
@@ -103,10 +104,10 @@ immediately after `Get` returns. The running browser process remains authoritati
 retry, or fall back to a private environment. If
 `CreateOrJoinCoreWebView2ClusterEnvironment` reports
 `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_NOT_SUPPORTED` (this host cannot use a cluster
-environment), use a
-private environment. A private environment is an ordinary environment created with
-your own user data folder through `CreateCoreWebView2EnvironmentWithOptions`; it has
-its own data and does not share with the cluster.
+environment), use a private environment. A private environment is an ordinary
+environment created with its own user data folder through
+`CreateCoreWebView2EnvironmentWithOptions`; it has its own data and does not share with
+the cluster.
 
 Options **match** when every option on `ICoreWebView2ClusterEnvironmentOptions`
 except `ClusterName` is equal: each scalar and boolean option is equal, `AdditionalBrowserArguments`
@@ -120,14 +121,13 @@ Profile isolation in a cluster is **anti-misuse, not a security boundary**. When
 `PerHostProfileIsolation` is TRUE (the default), the Edge browser profile names used
 within the cluster's shared user data folder are namespaced per host application, so
 two different host applications that use the same profile name do not accidentally end
-up sharing one profile. Here a "host application" is
-identified by its main executable file name (the same host identity WebView2 already
-derives to distinguish apps), compared case-insensitively. This is not a
-security boundary: it does not encrypt profile data or apply access control lists to
-it, the host identity is not authenticated, and applications that run from an
-executable with the same file name, or that deliberately use the same host identity and
-profile name, can still share a profile. Do not rely on it to isolate mutually
-distrusting code.
+up sharing one profile. Here a "host application" is identified by its main executable
+file name (the same host identity WebView2 already derives to distinguish apps),
+compared case-insensitively. This is not a security boundary: it does not encrypt
+profile data or apply access control lists to it, the host identity is not
+authenticated, and applications that run from an executable with the same file name, or
+that deliberately use the same host identity and profile name, can still share a
+profile. Do not rely on it to isolate mutually distrusting code.
 
 Because a cluster shares one browser process, environment-wide process diagnostics
 can expose frame names and last-committed URLs for frames owned by other hosts in the
@@ -577,7 +577,8 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   /// Sets the `AreBrowserExtensionsEnabled` property.
   [propput] HRESULT AreBrowserExtensionsEnabled([in] BOOL value);
 
-  /// When TRUE (the default), profile names are isolated per host application to
+  /// When TRUE (the default), the Edge browser profile names used within the
+  /// cluster's shared user data folder are namespaced per host application, to
   /// prevent accidental cross-app profile use. This is not a security boundary.
   [propget] HRESULT PerHostProfileIsolation([out, retval] BOOL* value);
   /// Sets the `PerHostProfileIsolation` property.
@@ -629,6 +630,8 @@ interface ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler : IUnknown
   ///  * `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH` - a cluster
   ///    already exists for this `ClusterName` with different options; `result.Environment`
   ///    is `nullptr`.
+  ///  * `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_NOT_SUPPORTED` - this host cannot
+  ///    use cluster environments; `result.Environment` is `nullptr`.
   ///
   /// When `errorCode` is a failing `HRESULT`, the operation started but then failed
   /// after start (for example, the browser process could not be launched), and

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -13,10 +13,9 @@ second host has no way to learn what those pinned options are before it attaches
 If the second host's options disagree with the pinned set, it only finds out after
 it has already paid to launch, and the failure surfaces as a generic create error.
 
-We want a first-class, *explicit* way for a set of cooperating host apps (for
-example, a shell and the widgets it hosts) to opt into one shared WebView2 browser
-process tree — a "cluster" — and to negotiate the shared options up front rather
-than by accident.
+We want a first-class, *explicit* way for a set of cooperating host apps to opt into
+one shared WebView2 environment — a "cluster" — and to agree on the shared options up
+front.
 
 This spec proposes the **symmetric `Create` + synchronous `Get`** model:
 
@@ -34,19 +33,12 @@ cooperating hosts agree on). The mapping from `Id` to on-disk UDF path is a fixe
 function, so the same `Id` always resolves to the same layout and first-creator-wins
 applies to the on-disk layout, not just to the live process.
 
-This spec covers the **public API surface and behavior**. Two alternative shapes that
-were considered (a `Create`/`Join` role split, and a single synchronous getter keyed
-on today's UDF) are summarized in the Appendix for reviewer context.
-
 # Conceptual pages (How To)
-
-_(This is conceptual documentation that will go to learn.microsoft.com "how to" page)_
 
 A **cluster environment** is a WebView2 environment that a group of cooperating
 host applications deliberately share, identified by a well-known `Id` string that
-those hosts agree on out of band (for example a constant in a shared header). All
-hosts that establish a cluster with the same `Id` run inside one browser process
-tree and one on-disk user data folder.
+those hosts agree on out of band. All hosts that establish a cluster with the same
+`Id` run inside one browser process tree and one on-disk user data folder.
 
 Unlike `CreateCoreWebView2EnvironmentWithOptions`, you do **not** pass a user data
 folder. The runtime derives the folder from the cluster `Id` through a fixed

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -34,10 +34,9 @@ cooperating hosts agree on). The mapping from `Id` to on-disk UDF path is a fixe
 function, so the same `Id` always resolves to the same layout and first-creator-wins
 applies to the on-disk layout, not just to the live process.
 
-This spec covers the **public API surface only**; storage, locking, and process
-management are implementation details summarized in the Appendix. Two alternative
-shapes that were considered (a `Create`/`Join` role split, and a single synchronous
-getter keyed on today's UDF) are described in the Appendix for reviewer context.
+This spec covers the **public API surface and behavior**. Two alternative shapes that
+were considered (a `Create`/`Join` role split, and a single synchronous getter keyed
+on today's UDF) are summarized in the Appendix for reviewer context.
 
 # Conceptual pages (How To)
 

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -35,12 +35,17 @@ Sharing intent is expressed by an `Id` (a stable rendezvous name that all
 cooperating hosts agree on). The mapping from `Id` to on-disk user data folder is a
 fixed function, so the same `Id` always resolves to the same folder.
 
-# Conceptual pages (How To)
+# Description
 
 A **cluster environment** is a WebView2 environment that a group of cooperating
 host applications deliberately share, identified by a well-known `Id` string that
 those hosts agree on out of band. All hosts that establish a cluster with the same
 `Id` run inside one shared browser process and one on-disk user data folder.
+
+Cluster environments are supported only for Win32 desktop host processes in this
+initial version. A host that cannot share or access the cluster's user data folder,
+such as a sandboxed AppContainer process (for example a UWP app), is not
+supported and the operation fails with `ERROR_NOT_SUPPORTED`.
 
 Unlike `CreateCoreWebView2EnvironmentWithOptions`, you do **not** pass a user data
 folder. The runtime derives the folder from the cluster `Id` through a fixed
@@ -51,8 +56,11 @@ with an environment created by `CreateCoreWebView2EnvironmentWithOptions`.
 The **cluster options** are the `ICoreWebView2ClusterEnvironmentOptions` that the
 first host to establish the cluster supplied. They apply to the whole shared browser
 process and are shared by every host that attaches, so the first establishing
-caller's set is authoritative for the lifetime of the cluster; there is no per-host
-override. This type intentionally exposes only a subset of the environment options.
+caller's set is authoritative for as long as the cluster's browser process is
+running; there is no per-host override. A cluster exists only while its browser
+process is running: once that process exits, the cluster no longer exists, and the
+next host to create may supply a different set of options. This type intentionally
+exposes only a subset of the environment options.
 
 The recommended usage pattern is **"Get, then Create"**:
 
@@ -65,19 +73,30 @@ The recommended usage pattern is **"Get, then Create"**:
 
 `Get` is only a hint: it can race with another host that establishes a cluster with
 different options the instant after you read. The live browser stays authoritative,
-so `Create` still validates and reports a status of
-`COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH` if you lost the race, at
-which point you re-`Get` the now-authoritative options and retry, or fall back to a
+so `Create` still validates. If it reports a status of
+`COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`, re-`Get` the
+now-authoritative options and retry, or fall back to a private environment. If it
+fails with `ERROR_NOT_SUPPORTED` (this host cannot use a cluster environment), use a
 private environment. A private environment is an ordinary environment created with
 your own user data folder through `CreateCoreWebView2EnvironmentWithOptions`; it has
 its own separate data and does not share with the cluster.
 
+Options **match** when every option on `ICoreWebView2ClusterEnvironmentOptions`
+except `Id` is equal: each scalar and boolean option is equal, `AdditionalBrowserArguments`
+is the same string (compared exactly, with no normalization of whitespace or switch
+order), and the custom scheme registrations are the same in the same order. `Id`
+identifies the cluster and is not part of this comparison.
+
 Profile isolation in a cluster is **anti-misuse, not a security boundary**. When
 `PerHostProfileIsolation` is TRUE (the default), profile names are namespaced per
-host application, so two different apps that happen to use the same profile name do
-not accidentally end up sharing one profile. This is not a security boundary: it
-does not encrypt or ACL profile data, and apps that deliberately use the same host
-identity and profile name can still share a profile.
+host application, so two different applications that happen to use the same profile
+name do not accidentally end up sharing one profile. This is not a security boundary:
+it does not encrypt or ACL profile data, and applications that deliberately use the
+same host identity and profile name can still share a profile.
+
+Because a cluster shares one browser process, environment-wide process diagnostics
+can expose frame names and last-committed URLs for frames owned by other hosts in the
+cluster. Cluster members must trust one another with this metadata.
 
 # Examples
 
@@ -108,11 +127,17 @@ void AppWindow::CreateSharedEnvironment()
     wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> existing;
     HRESULT hr = GetCoreWebView2ClusterEnvironmentOptions(kClusterId, &existing);
 
-    // Step 2 - reuse the cluster's options if it already exists; offer my own if none
-    // exists yet. If cluster environments are not supported in this host, go private.
+    // Step 2 - if a cluster already exists, decide whether its options are acceptable
+    // before attaching; if not, use a private environment. Offer my own options if no
+    // cluster exists yet, or go private if cluster environments are not supported here.
     wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> options;
     if (SUCCEEDED(hr))
     {
+        if (!AcceptableForMe(existing.get()))
+        {
+            UsePrivateEnvironment();
+            return;
+        }
         options = existing;
     }
     else if (hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND))
@@ -121,7 +146,7 @@ void AppWindow::CreateSharedEnvironment()
     }
     else if (hr == HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED))
     {
-        // Sandboxed or low-integrity process (for example a UWP app) that cannot
+        // Sandboxed AppContainer process (for example a UWP app) that cannot
         // share or access the cluster's user data folder.
         UsePrivateEnvironment();
         return;
@@ -146,8 +171,10 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
             [this](HRESULT errorCode,
                    ICoreWebView2ClusterEnvironmentCreateResult* result) -> HRESULT
             {
-                // A failing errorCode is an unexpected failure (for example the
-                // runtime could not be found). Handle it as usual.
+                // A failing errorCode means the environment could not be created (for
+                // example the WebView2 Runtime could not be found). Handle it the same
+                // way as a failure from CreateCoreWebView2EnvironmentWithOptions (for
+                // example, surface an error and stop).
                 CHECK_FAILURE(errorCode);
 
                 COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS status;
@@ -188,7 +215,7 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
     if (hr == HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED))
     {
         // This host cannot share or access the cluster's user data folder (for
-        // example a sandboxed or low-integrity process such as a UWP app). Cluster
+        // example a sandboxed AppContainer process such as a UWP app). Cluster
         // environments are unavailable here; use a private environment instead.
         UsePrivateEnvironment();
         return;
@@ -222,12 +249,20 @@ async Task CreateSharedEnvironmentAsync()
         CoreWebView2ClusterEnvironmentOptions existing =
             CoreWebView2Environment.GetClusterEnvironmentOptions(ClusterId);
 
-        // Step 2 - reuse the cluster's options, or offer my own if none exists yet.
+        // Step 2 - if a cluster already exists, decide whether its options are
+        // acceptable before attaching; if not, use a private environment. Offer my
+        // own options if no cluster exists yet.
+        if (existing != null && !AcceptableForMe(existing))
+        {
+            UsePrivateEnvironment();
+            return;
+        }
         CoreWebView2ClusterEnvironmentOptions options = existing ?? BuildClusterOptions();
 
-        // Step 3 - same symmetric create either way. A failing create (for example
-        // the runtime could not be found, or cluster environments are not supported
-        // in this host) throws an exception; the expected outcomes come back as Status.
+        // Step 3 - same symmetric create either way. If the environment cannot be
+        // created (for example the WebView2 Runtime could not be found, or cluster
+        // environments are not supported in this host) the call throws, the same as
+        // CreateAsync; the expected outcomes come back as Status.
         CoreWebView2ClusterEnvironmentCreateResult result =
             await CoreWebView2Environment.CreateOrJoinClusterEnvironmentAsync(options);
 
@@ -256,7 +291,7 @@ async Task CreateSharedEnvironmentAsync()
         }
     }
     // HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED). This host cannot share or access the
-    // cluster's user data folder (for example a sandboxed or low-integrity process
+    // cluster's user data folder (for example a sandboxed AppContainer process
     // such as a UWP app); use a private environment instead.
     catch (COMException ex) when (ex.HResult == unchecked((int)0x80070032))
     {
@@ -297,7 +332,7 @@ async Task CreateSharedEnvironmentAsync()
 ///                                              `handler` is not invoked.
 ///   HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) -> the host cannot share or access the
 ///                                              cluster's user data folder (for
-///                                              example a sandboxed or low-integrity
+///                                              example a sandboxed AppContainer
 ///                                              process such as a UWP app); `handler`
 ///                                              is not invoked.
 /// When the return value is any failing `HRESULT`, `handler` is not invoked.
@@ -306,14 +341,14 @@ STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
     [in] ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler* handler);
 
 /// Reads the options of the cluster identified by its `Id` without creating or
-/// attaching to a cluster. Returns `S_OK` and the cluster's options when a cluster
-/// exists for that `Id`, or `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)` and `nullptr`
-/// `options` when no cluster exists for that `Id`. The options are available
-/// whether or not the cluster is currently running.
+/// attaching to a cluster. A cluster exists only while its browser process is
+/// running. Returns `S_OK` and the cluster's options when a cluster is running for
+/// that `Id`, or `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)` and `nullptr` `options` when
+/// no cluster is running for that `Id`.
 ///
 /// Returns `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)` and `nullptr` `options` in hosts
-/// that cannot share or access the cluster's user data folder, for example a
-/// sandboxed or low-integrity process such as a UWP app.
+/// that cannot share or access the cluster's user data folder, such as a sandboxed
+/// AppContainer process (for example a UWP app).
 STDAPI GetCoreWebView2ClusterEnvironmentOptions(
     [in] LPCWSTR id,
     [out] ICoreWebView2ClusterEnvironmentOptions** options);
@@ -360,9 +395,23 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   /// Sets the `PerHostProfileIsolation` property.
   [propput] HRESULT PerHostProfileIsolation([in] BOOL value);
 
-  /// Gets the custom scheme registrations for the shared environment. The caller
-  /// must free the returned array and release each element with
-  /// `CoTaskMemFree` / `Release`.
+  /// The release channels the shared environment creation searches for, as a mask
+  /// of one or more `COREWEBVIEW2_RELEASE_CHANNELS`. Because the browser process is
+  /// shared, this selects the channel of the shared browser. The default is a mask
+  /// of all channels.
+  [propget] HRESULT ReleaseChannels([out, retval] COREWEBVIEW2_RELEASE_CHANNELS* value);
+  /// Sets the `ReleaseChannels` property.
+  [propput] HRESULT ReleaseChannels([in] COREWEBVIEW2_RELEASE_CHANNELS value);
+
+  /// The order that release channels are searched for during shared environment
+  /// creation. The default is `COREWEBVIEW2_CHANNEL_SEARCH_KIND_MOST_STABLE`.
+  [propget] HRESULT ChannelSearchKind([out, retval] COREWEBVIEW2_CHANNEL_SEARCH_KIND* value);
+  /// Sets the `ChannelSearchKind` property.
+  [propput] HRESULT ChannelSearchKind([in] COREWEBVIEW2_CHANNEL_SEARCH_KIND value);
+
+  /// Gets the custom scheme registrations for the shared environment. The returned
+  /// `ICoreWebView2CustomSchemeRegistration` pointers must be released, and the array
+  /// itself must be deallocated with `CoTaskMemFree`.
   HRESULT GetCustomSchemeRegistrations(
       [out] UINT32* count,
       [out] ICoreWebView2CustomSchemeRegistration*** schemeRegistrations);
@@ -394,7 +443,9 @@ interface ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler : IUnknown
   ///    is `nullptr`.
   ///
   /// When `errorCode` is a failing `HRESULT`, the operation failed for another reason
-  /// (for example, the WebView2 Runtime could not be found) and `result` is `nullptr`.
+  /// and `result` is `nullptr`. This is the same set of failures that
+  /// `CreateCoreWebView2EnvironmentWithOptions` can report (for example, the WebView2
+  /// Runtime could not be found).
   HRESULT Invoke(
       [in] HRESULT errorCode,
       [in] ICoreWebView2ClusterEnvironmentCreateResult* result);
@@ -409,7 +460,7 @@ mirroring how `CreateCoreWebView2EnvironmentWithOptions` maps to
 `CoreWebView2ClusterEnvironmentCreateResult` carrying the `Status` and, on success,
 the `Environment`. When the operation cannot be started or fails, it throws; in
 particular a host that cannot share or access the cluster's user data folder (for
-example a sandboxed or low-integrity process such as a UWP app) throws a
+example a sandboxed AppContainer process such as a UWP app) throws a
 `COMException` whose `HResult` is `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)`.
 `GetClusterEnvironmentOptions` returns `null` when no cluster exists for the id,
 matching the `ERROR_NOT_FOUND` case of the COM API.
@@ -441,6 +492,8 @@ namespace Microsoft.Web.WebView2.Core
         Boolean EnableTrackingPrevention { get; set; };
         Boolean AreBrowserExtensionsEnabled { get; set; };
         Boolean PerHostProfileIsolation { get; set; };
+        CoreWebView2ReleaseChannels ReleaseChannels { get; set; };
+        CoreWebView2ChannelSearchKind ChannelSearchKind { get; set; };
         IVector<CoreWebView2CustomSchemeRegistration> CustomSchemeRegistrations { get; };
     }
 
@@ -453,8 +506,8 @@ namespace Microsoft.Web.WebView2.Core
         // Environment is non-null only when Status is Succeeded. Throws when the
         // operation cannot be started or fails, including
         // HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) when the host cannot share or
-        // access the cluster's user data folder (for example a sandboxed or
-        // low-integrity process such as a UWP app).
+        // access the cluster's user data folder (for example a sandboxed
+        // AppContainer process such as a UWP app).
         static Windows.Foundation.IAsyncOperation<CoreWebView2ClusterEnvironmentCreateResult>
             CreateOrJoinClusterEnvironmentAsync(CoreWebView2ClusterEnvironmentOptions options);
 

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -266,7 +266,6 @@ STDAPI GetCoreWebView2ClusterEnvironmentOptions(
 /// The options used to establish or attach to a shared cluster environment. Only
 /// options that can be shared process-wide across cooperating hosts are present;
 /// process-incompatible options are intentionally omitted.
-[uuid(2F3A6D1E-6B9C-4E2A-9A1B-4C0F2D8E7A10), object, pointer_default(unique)]
 interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   /// The rendezvous name that identifies the cluster. All cooperating hosts agree
   /// on this value out of band. Must not be null or empty.
@@ -334,7 +333,6 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
 }
 
 /// Receives the result of `CreateOrJoinCoreWebView2ClusterEnvironment`.
-[uuid(6C4B0A72-1D8E-4F3B-8C2A-5E9D7B1A0C34), object, pointer_default(unique)]
 interface ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler : IUnknown {
   /// `errorCode` is:
   ///  * `S_OK` - `environment` is the shared cluster environment (freshly

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -7,28 +7,29 @@ Today an application creates a WebView2 by calling
 [`CreateCoreWebView2EnvironmentWithOptions`](https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions)
 and passing a `UserDataFolder` (UDF). Two hosts that pass the *same* UDF already
 share a single browser process. But that sharing is implicit: it is keyed
-entirely on the UDF path, the first launcher silently fixes the environment options
-for everyone else, and a second host has no way to learn what those options
+entirely on the UDF path, the first launcher silently determines the environment
+options for everyone else, and a second host has no way to learn what those options
 are before it attaches. If the second host's options disagree with the existing set,
-it only finds out after it has already paid to launch, and the failure surfaces as a
-generic create error.
+it only finds out after it has already attempted to create the environment, and the
+failure surfaces as a generic create error.
 
-We want a first-class, *explicit* way for a set of cooperating host apps to opt into
-one shared WebView2 environment — a "cluster" — and to agree on the shared options up
-front. By cooperating host apps we mean applications that trust one another and agree
-on a shared cluster `Id` out of band; sharing is by convention, and the runtime does
-not restrict which apps may join a cluster.
+We want a first-class, *explicit* way for a set of cooperating host applications to
+opt into one shared WebView2 environment — a "cluster" — and to agree on the shared
+options up front. Cooperating host applications are applications that trust one
+another and agree on a shared cluster `Id` in advance; sharing is by convention, and
+the WebView2 Runtime does not restrict which applications may join a cluster.
 
-This spec proposes the **symmetric create-or-join + synchronous `Get`** model:
+This spec proposes a symmetric create-or-join model and a companion read of a
+cluster's options:
 
 - Every host calls the same symmetric `CreateOrJoinCoreWebView2ClusterEnvironment` with
   its full desired options. The **first** host to establish a cluster with a given
-  `Id` fixes the cluster's options (first-creator-wins). A later host that passes matching
-  options attaches to the running cluster; a host that passes different options gets a
-  completion status of `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`.
-- A separate **synchronous** `GetCoreWebView2ClusterEnvironmentOptions` reads the
-  cluster's options back for an `Id` without spawning a browser, so a host can
-  pre-flight: read what the cluster already uses, decide whether it likes it, then create.
+  `Id` determines the cluster's options (first-creator-wins). A later host that passes
+  matching options attaches to the running cluster; a host that passes different
+  options gets a completion status of `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`.
+- A separate `GetCoreWebView2ClusterEnvironmentOptions` reads the cluster's options
+  for an `Id` without launching the shared browser process, so a host can read a
+  cluster's current options before it creates.
 
 Sharing intent is expressed by an `Id` (a stable rendezvous name that all
 cooperating hosts agree on). The mapping from `Id` to on-disk user data folder is a
@@ -52,12 +53,13 @@ first host to establish the cluster supplied. They apply to the whole shared bro
 process and are shared by every host that attaches, so the first establishing
 caller's set is authoritative for the lifetime of the cluster; there is no per-host
 override. This type intentionally exposes only a subset of the environment options.
+
 The recommended usage pattern is **"Get, then Create"**:
 
-1. Synchronously `GetCoreWebView2ClusterEnvironmentOptions(id)` to see what options,
-   if any, the cluster already uses. This does not launch a browser.
-2. If a cluster exists, reuse its options (attach). If none exists yet, offer your
-   own options (yours become the cluster's).
+1. Call `GetCoreWebView2ClusterEnvironmentOptions(id)` to see what options, if any,
+   the cluster already uses. This does not launch the shared browser process.
+2. If a cluster already exists, reuse its options and attach to it. If none exists
+   yet, provide your own options, which become the cluster's options.
 3. Call `CreateOrJoinCoreWebView2ClusterEnvironment` with the chosen options. You either
    establish the cluster or attach to one with matching options.
 
@@ -90,8 +92,8 @@ with matching options). On a mismatch, re-read the authoritative options and ret
 // A stable rendezvous name that all cooperating hosts agree on.
 constexpr PCWSTR kClusterId = L"Contoso.Shell.Default";
 
-// Build the options this host would like if it turns out to be the first one in.
-wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> BuildMyOptions()
+// Build the options this host would use if it is the first to establish the cluster.
+wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> BuildClusterOptions()
 {
     auto options = Microsoft::WRL::Make<CoreWebView2ClusterEnvironmentOptions>();
     CHECK_FAILURE(options->put_Id(kClusterId));
@@ -115,7 +117,7 @@ void AppWindow::CreateSharedEnvironment()
     }
     else if (hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND))
     {
-        options = BuildMyOptions();
+        options = BuildClusterOptions();
     }
     else if (hr == HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED))
     {
@@ -201,7 +203,7 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
 // A stable rendezvous name that all cooperating hosts agree on.
 const string ClusterId = "Contoso.Shell.Default";
 
-CoreWebView2ClusterEnvironmentOptions BuildMyOptions()
+CoreWebView2ClusterEnvironmentOptions BuildClusterOptions()
 {
     return new CoreWebView2ClusterEnvironmentOptions()
     {
@@ -221,11 +223,11 @@ async Task CreateSharedEnvironmentAsync()
             CoreWebView2Environment.GetClusterEnvironmentOptions(ClusterId);
 
         // Step 2 - reuse the cluster's options, or offer my own if none exists yet.
-        CoreWebView2ClusterEnvironmentOptions options = existing ?? BuildMyOptions();
+        CoreWebView2ClusterEnvironmentOptions options = existing ?? BuildClusterOptions();
 
         // Step 3 - same symmetric create either way. A failing create (for example
         // the runtime could not be found, or cluster environments are not supported
-        // in this host) throws; the expected outcomes come back as Status.
+        // in this host) throws an exception; the expected outcomes come back as Status.
         CoreWebView2ClusterEnvironmentCreateResult result =
             await CoreWebView2Environment.CreateOrJoinClusterEnvironmentAsync(options);
 
@@ -305,11 +307,11 @@ STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
 
 /// Synchronously reads the options of the cluster identified by `id` without
 /// creating or attaching to a cluster. Returns `S_OK` and the cluster's options
-/// when a cluster is configured for `id`, or `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)`
-/// and null `options` when none is. The options are available whether or not the
-/// cluster is currently running.
+/// when a cluster exists for `id`, or `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)`
+/// and `nullptr` `options` when no cluster exists for `id`. The options are available
+/// whether or not the cluster is currently running.
 ///
-/// Returns `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)` and null `options` in hosts
+/// Returns `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)` and `nullptr` `options` in hosts
 /// that cannot share or access the cluster's user data folder, for example a
 /// sandboxed or low-integrity process such as a UWP app.
 STDAPI GetCoreWebView2ClusterEnvironmentOptions(
@@ -319,9 +321,9 @@ STDAPI GetCoreWebView2ClusterEnvironmentOptions(
 /// The options used to establish or attach to a shared cluster environment.
 interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   /// The name that identifies the cluster. All cooperating hosts use the same
-  /// value. Use a stable, descriptive name your apps agree on (for example
-  /// `"Contoso.Shell.Default"`); it does not need to be a GUID. Must not be null or
-  /// empty. The `Id` is case-insensitive and must be a valid file-system folder
+  /// value. Use a stable, descriptive name your applications agree on (for example
+  /// `"Contoso.Shell.Default"`); it does not need to be a GUID. Must not be `nullptr`
+  /// or empty. The `Id` is case-insensitive and must be a valid file-system folder
   /// name; otherwise the call fails with `E_INVALIDARG`.
   [propget] HRESULT Id([out, retval] LPWSTR* id);
   /// Sets the `Id` property.
@@ -378,7 +380,7 @@ interface ICoreWebView2ClusterEnvironmentCreateResult : IUnknown {
       [out, retval] COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS* value);
 
   /// The shared cluster environment. This is non-null only when `Status` is
-  /// `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED`; otherwise it is null.
+  /// `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED`; otherwise it is `nullptr`.
   [propget] HRESULT Environment([out, retval] ICoreWebView2Environment** value);
 }
 
@@ -389,10 +391,10 @@ interface ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler : IUnknown
   ///    is the shared cluster environment.
   ///  * `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH` - a cluster
   ///    already exists for this `Id` with different options; `result.Environment`
-  ///    is null.
+  ///    is `nullptr`.
   ///
   /// When `errorCode` is a failing `HRESULT`, the operation failed for another reason
-  /// (for example, the WebView2 Runtime could not be found) and `result` is null.
+  /// (for example, the WebView2 Runtime could not be found) and `result` is `nullptr`.
   HRESULT Invoke(
       [in] HRESULT errorCode,
       [in] ICoreWebView2ClusterEnvironmentCreateResult* result);
@@ -409,8 +411,8 @@ the `Environment`. When the operation cannot be started or fails, it throws; in
 particular a host that cannot share or access the cluster's user data folder (for
 example a sandboxed or low-integrity process such as a UWP app) throws a
 `COMException` whose `HResult` is `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)`.
-`GetClusterEnvironmentOptions` is synchronous and returns `null` when no cluster is
-configured, matching the `ERROR_NOT_FOUND` case of the COM API.
+`GetClusterEnvironmentOptions` returns `null` when no cluster exists for the id,
+matching the `ERROR_NOT_FOUND` case of the COM API.
 
 ```c#
 namespace Microsoft.Web.WebView2.Core
@@ -457,7 +459,7 @@ namespace Microsoft.Web.WebView2.Core
             CreateOrJoinClusterEnvironmentAsync(CoreWebView2ClusterEnvironmentOptions options);
 
         // Synchronously reads the options of the cluster identified by id. Returns
-        // null when no cluster is configured for id. Throws a COMException whose
+        // null when no cluster exists for id. Throws a COMException whose
         // HResult is HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) when the host cannot
         // share or access the cluster's user data folder.
         static CoreWebView2ClusterEnvironmentOptions GetClusterEnvironmentOptions(

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -229,63 +229,36 @@ async Task CreateSharedEnvironmentAsync()
 ## Win32 C++
 
 ```
-/// Establishes, or attaches to, a shared WebView2 cluster environment identified by
-/// the `Id` in `options`. This is the symmetric entry point every cooperating host
-/// calls with its full desired options.
-///
-/// The first host to establish a cluster for a given `Id` pins its options
-/// (first-creator-wins). A later host attaches when its options equal the pinned
-/// set (strict, full-set equality), and the completion handler receives the shared
-/// `ICoreWebView2Environment`. A host whose options differ from the pinned set does
-/// not attach: the completion handler is invoked with
-/// `ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH` and a null environment; that host
-/// should call `GetCoreWebView2ClusterEnvironmentOptions` to read the authoritative
-/// set and retry, or create a private (non-shared) environment instead.
-///
-/// The mapping from `Id` to the on-disk user data folder is a fixed function, so
-/// the same `Id` always resolves to the same layout.
+/// Establishes, or attaches to, the shared WebView2 cluster environment identified
+/// by the `Id` in `options`. If no cluster exists for the `Id`, this establishes
+/// one and the caller's options become the cluster's options. If a cluster already
+/// exists and the caller's options match it, the completion handler receives the
+/// shared `ICoreWebView2Environment`. If they do not match, the completion handler
+/// is invoked with `ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH` and a null
+/// environment.
 STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
     [in] ICoreWebView2ClusterEnvironmentOptions* options,
     [in] ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler* handler);
 
-/// Synchronously reads the pinned options for the cluster identified by `id`,
-/// without spawning a browser. Use this to pre-flight before calling
-/// `CreateOrJoinCoreWebView2ClusterEnvironment`: read what is already pinned and decide
-/// whether to reuse it or offer your own set.
-///
-/// Returns `S_OK` and the pinned options when a set is pinned for `id`. Returns
-/// `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)` and null `options` when nothing is pinned
-/// for `id` yet (the caller may create with its own options and become the pinner).
-///
-/// The value returned is a hint: it can be stale the instant it is read if another
-/// host pins a different set concurrently. `CreateOrJoinCoreWebView2ClusterEnvironment`
-/// remains authoritative and validates against the live cluster.
-///
-/// State: the pinned options are persisted per cluster `Id` in the user data folder
-/// resolved from that `Id`. The record survives after the cluster's browser process
-/// exits, so `Get` answers whether or not the cluster is currently running.
+/// Synchronously reads the options of the cluster identified by `id` without
+/// creating or attaching to a cluster. Returns `S_OK` and the cluster's options
+/// when a cluster is configured for `id`, or `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)`
+/// and null `options` when none is. The options are available whether or not the
+/// cluster is currently running.
 STDAPI GetCoreWebView2ClusterEnvironmentOptions(
     [in] LPCWSTR id,
     [out] ICoreWebView2ClusterEnvironmentOptions** options);
 
-/// The options used to establish or attach to a shared cluster environment. Only
-/// options that can be shared process-wide across cooperating hosts are present;
-/// process-incompatible options are intentionally omitted.
+/// The options used to establish or attach to a shared cluster environment.
 interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
-  /// The rendezvous name that identifies the cluster. All cooperating hosts agree
-  /// on this value out of band. Must not be null or empty.
-  ///
-  /// Because the `Id` is mapped to an on-disk user data folder, it is treated as a
-  /// case-insensitive name and must be a valid file-system folder name: it cannot
-  /// contain path separators or characters that are invalid in a folder name, and
-  /// its length must fit within the platform path limit once combined with the
-  /// runtime's base path. An invalid `Id` fails the call with `E_INVALIDARG`.
+  /// The name that identifies the cluster. All cooperating hosts use the same
+  /// value. Must not be null or empty. The `Id` is case-insensitive and must be a
+  /// valid file-system folder name; otherwise the call fails with `E_INVALIDARG`.
   [propget] HRESULT Id([out, retval] LPWSTR* id);
   /// Sets the `Id` property.
   [propput] HRESULT Id([in] LPCWSTR id);
 
-  /// Additional command-line switches passed to the shared browser process. Because
-  /// the process is shared, this value is part of the pinned set and is process-wide.
+  /// Additional command-line switches passed to the shared browser process.
   [propget] HRESULT AdditionalBrowserArguments([out, retval] LPWSTR* value);
   /// Sets the `AdditionalBrowserArguments` property.
   [propput] HRESULT AdditionalBrowserArguments([in] LPCWSTR value);
@@ -317,21 +290,20 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   [propput] HRESULT ChannelSearchKind([in] COREWEBVIEW2_CHANNEL_SEARCH_KIND value);
 
   /// When TRUE (the default), the effective profile name is namespaced per host
-  /// application (`"<HostName>_<ProfileName>"`) to prevent *accidental* cross-app
-  /// profile use. This is anti-misuse, not a security boundary. The name is
-  /// deliberately OS-neutral: `<HostName>` is the host application identity on the
-  /// current platform (the executable name on Windows).
+  /// application (`"<HostName>_<ProfileName>"`, where `<HostName>` is the host
+  /// executable name on Windows) to prevent accidental cross-app profile use. This
+  /// is not a security boundary.
   [propget] HRESULT PerHostProfileIsolation([out, retval] BOOL* value);
   /// Sets the `PerHostProfileIsolation` property.
   [propput] HRESULT PerHostProfileIsolation([in] BOOL value);
 
-  /// Gets the custom scheme registrations that are part of the pinned set. The
-  /// caller must free the returned array and release each element with
+  /// Gets the custom scheme registrations for the shared environment. The caller
+  /// must free the returned array and release each element with
   /// `CoTaskMemFree` / `Release`.
   HRESULT GetCustomSchemeRegistrations(
       [out] UINT32* count,
       [out] ICoreWebView2CustomSchemeRegistration*** schemeRegistrations);
-  /// Sets the custom scheme registrations that are part of the pinned set.
+  /// Sets the custom scheme registrations for the shared environment.
   HRESULT SetCustomSchemeRegistrations(
       [in] UINT32 count,
       [in] const ICoreWebView2CustomSchemeRegistration** schemeRegistrations);
@@ -340,12 +312,10 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
 /// Receives the result of `CreateOrJoinCoreWebView2ClusterEnvironment`.
 interface ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler : IUnknown {
   /// `errorCode` is:
-  ///  * `S_OK` - `environment` is the shared cluster environment (freshly
-  ///    established, or attached to an identical running cluster).
+  ///  * `S_OK` - `environment` is the shared cluster environment, either freshly
+  ///    established or attached to an existing cluster with matching options.
   ///  * `ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH` - a cluster already exists for
-  ///    this `Id` with a different pinned set; `environment` is null. Call
-  ///    `GetCoreWebView2ClusterEnvironmentOptions` to read the authoritative set and
-  ///    retry, or create a private environment.
+  ///    this `Id` with different options; `environment` is null.
   HRESULT Invoke(
       [in] HRESULT errorCode,
       [in] ICoreWebView2Environment* environment);
@@ -360,11 +330,8 @@ interface ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler : IUnknown
 The two global functions are surfaced as static methods on `CoreWebView2Environment`,
 mirroring how `CreateCoreWebView2EnvironmentWithOptions` maps to
 `CoreWebView2Environment.CreateAsync`. `GetClusterEnvironmentOptions` is synchronous
-and returns `null` when nothing is pinned (rather than throwing), matching the
-`ERROR_NOT_FOUND` case of the COM API. It is deliberately synchronous even though it
-reads persisted state: the read is small and bounded, and the whole point of the
-pre-flight is to let a host decide *before* it begins the async create, without
-threading an extra `await` through startup code.
+and returns `null` when no cluster is configured, matching the `ERROR_NOT_FOUND` case
+of the COM API.
 
 ```c#
 namespace Microsoft.Web.WebView2.Core
@@ -391,12 +358,12 @@ namespace Microsoft.Web.WebView2.Core
         // Establishes, or attaches to, the shared cluster identified by
         // options.Id. Throws a COMException whose HResult is
         // HRESULT_FROM_WIN32(ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH) when a
-        // cluster already exists for that Id with a different pinned set.
+        // cluster already exists for that Id with different options.
         static Windows.Foundation.IAsyncOperation<CoreWebView2Environment>
             CreateOrJoinClusterEnvironmentAsync(CoreWebView2ClusterEnvironmentOptions options);
 
-        // Synchronously reads the pinned options for the cluster id without
-        // spawning a browser. Returns null when nothing is pinned for id yet.
+        // Synchronously reads the options of the cluster identified by id. Returns
+        // null when no cluster is configured for id.
         static CoreWebView2ClusterEnvironmentOptions GetClusterEnvironmentOptions(
             String id);
     }

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -5,31 +5,33 @@ Shared WebView2 Cluster Environment
 
 Today an application creates a WebView2 by calling
 [`CreateCoreWebView2EnvironmentWithOptions`](https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions)
-and passing a `UserDataFolder` (UDF). Two hosts that pass the *same* UDF already
+and passing a `userDataFolder` (UDF). Two hosts that pass the *same* UDF already
 share a single browser process. But that sharing is implicit: it is keyed
-entirely on the UDF path, the first launcher silently determines the environment
-options for everyone else, and a second host has no way to learn what those options
-are before it attaches. If the second host's options disagree with the existing set,
+entirely on the UDF path, the first host silently determines the environment
+options for all later hosts, and a second host has no way to learn what those options
+are before the second host attaches to the shared browser process. If the second
+host's options disagree with the existing set,
 it only finds out after it has already attempted to create the environment, and the
 failure surfaces as a generic create error.
 
 We want a first-class, *explicit* way for a set of cooperating host applications to
-opt into one shared WebView2 environment — a "cluster" — and to agree on the shared
-options up front. Cooperating host applications are applications that trust one
+opt into one shared WebView2 environment—a "cluster"—and to agree on the shared
+options up front. Cooperating host applications trust one
 another and agree on a shared cluster `Id` in advance; sharing is by convention, and
 the WebView2 Runtime does not restrict which applications may join a cluster.
 
-This spec proposes a symmetric create-or-join model and a companion read of a
+This spec proposes a symmetric create-or-join model and a companion operation that reads a
 cluster's options:
 
 - Every host calls the same symmetric `CreateOrJoinCoreWebView2ClusterEnvironment` with
   its full desired options. The **first** host to establish a cluster with a given
   `Id` determines the cluster's options (first-creator-wins). A later host that passes
   matching options attaches to the running cluster; a host that passes different
-  options gets a completion status of `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`.
+  options receives a completion status of
+  `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`.
 - A separate `GetCoreWebView2ClusterEnvironmentOptions` reads the cluster's options
   for an `Id` without launching the shared browser process, so a host can read a
-  cluster's current options before it creates.
+  cluster's current options before the host calls the create-or-join operation.
 
 Sharing intent is expressed by an `Id` (a stable rendezvous name that all
 cooperating hosts agree on). The mapping from `Id` to on-disk user data folder is a
@@ -42,32 +44,41 @@ host applications deliberately share, identified by a well-known `Id` string tha
 those hosts agree on out of band. All hosts that establish a cluster with the same
 `Id` run inside one shared browser process and one on-disk user data folder.
 
-Cluster environments are supported only for Win32 desktop host processes in this
-initial version. A host that cannot share or access the cluster's user data folder,
-such as a sandboxed AppContainer process (for example a UWP app), is not
-supported and the operation fails with `ERROR_NOT_SUPPORTED`.
+A host process must be able to create and share the cluster's per-user user data
+folder. A host that cannot, such as a sandboxed AppContainer process (for example, a
+UWP app), fails with `ERROR_NOT_SUPPORTED`. A transient failure to access an
+otherwise-supported cluster's user data folder (for example, an access-denied or
+sharing violation) is not reported as `ERROR_NOT_SUPPORTED`; it surfaces as an ordinary
+create failure.
+
+These entry points exist only in WebView2 Runtime versions that implement them. On an
+older runtime they are unavailable, so a host should feature-detect the API using the
+standard WebView2 versioning guidance and fall back to a private environment when it
+is absent.
 
 Unlike `CreateCoreWebView2EnvironmentWithOptions`, you do **not** pass a user data
 folder. The runtime derives the folder from the cluster `Id`, so every host that uses
-the same `Id` resolves to the same on-disk location. The folder is created under a
-per-user cluster root, `%LOCALAPPDATA%\Microsoft\WebView2Clusters\<Id>`, with the
-`Id` as the leaf folder name (this is why the `Id` must be a valid folder name). A
-cluster occupies its own user data folder namespace: folders under this root are
-reachable only through the cluster API. Even if a caller passes a cluster folder path
-explicitly to `CreateCoreWebView2EnvironmentWithOptions`, that call is rejected and
-does not join the cluster, so a cluster never joins or collides with an environment
-created through the ordinary create path.
+the same `Id` resolves to the same on-disk location. `Id` comparison is
+case-insensitive, so `Id` values that differ only in case refer to the same cluster.
+The folder is created under a per-user cluster root,
+`%LOCALAPPDATA%\Microsoft\WebView2Clusters\<Id>`, with the `Id` as the leaf folder
+name (this is why the `Id` must be a valid folder name). A cluster occupies its own
+user data folder namespace: folders under this root are reachable only through the
+cluster API. Even if a caller passes a cluster folder path explicitly to
+`CreateCoreWebView2EnvironmentWithOptions`, that call is rejected and does not join the
+cluster, so a cluster never joins or collides with an environment created through the
+ordinary create path.
 
 The **cluster options** are the `ICoreWebView2ClusterEnvironmentOptions` that the
 first host to establish the cluster supplied. They apply to the whole shared browser
-process and are shared by every host that attaches, so the first establishing
-caller's set is authoritative for as long as the cluster's browser process is
+process and are shared by every host that attaches, so the options supplied by the
+first host are authoritative for as long as the cluster's browser process is
 running; there is no per-host override. A cluster exists only while its browser
 process is running: once that process exits, the cluster no longer exists, and the
 next host to create may supply a different set of options. This type intentionally
 exposes only a subset of the environment options.
 
-The recommended usage pattern is **"Get, then Create"**:
+The recommended usage pattern is **"Get, then create or join"**:
 
 1. Call `GetCoreWebView2ClusterEnvironmentOptions(id)` to see what options, if any,
    the cluster already uses. This does not launch the shared browser process.
@@ -76,39 +87,67 @@ The recommended usage pattern is **"Get, then Create"**:
 3. Call `CreateOrJoinCoreWebView2ClusterEnvironment` with the chosen options. You either
    establish the cluster or attach to one with matching options.
 
-`Get` is only a hint: it can race with another host that establishes a cluster with
-different options the instant after you read. The live browser stays authoritative,
-so `Create` still validates. If it reports a status of
-`COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`, re-`Get` the
-now-authoritative options and retry, or fall back to a private environment. If it
+`Get` is only a hint: another host can establish a cluster with different options
+immediately after `Get` returns. The running browser process remains authoritative, so
+`CreateOrJoinCoreWebView2ClusterEnvironment` still validates the supplied options. If
+`CreateOrJoinCoreWebView2ClusterEnvironment` reports
+`COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`, call
+`GetCoreWebView2ClusterEnvironmentOptions` again to read the authoritative options and
+retry, or fall back to a private environment. If
+`CreateOrJoinCoreWebView2ClusterEnvironment`
 fails with `ERROR_NOT_SUPPORTED` (this host cannot use a cluster environment), use a
 private environment. A private environment is an ordinary environment created with
 your own user data folder through `CreateCoreWebView2EnvironmentWithOptions`; it has
-its own separate data and does not share with the cluster.
+its own data and does not share with the cluster.
 
 Options **match** when every option on `ICoreWebView2ClusterEnvironmentOptions`
 except `Id` is equal: each scalar and boolean option is equal, `AdditionalBrowserArguments`
 is the same string (compared exactly, with no normalization of whitespace or switch
-order), and the custom scheme registrations are the same in the same order. `Id`
-identifies the cluster and is not part of this comparison.
+order), and the custom scheme registrations are the same in the same order. The
+release-channel options (`ReleaseChannels` and `ChannelSearchKind`) are part of this
+comparison, so a host requesting a different channel than the running cluster receives
+a mismatch. `Id` identifies the cluster and is not part of this comparison.
 
 Profile isolation in a cluster is **anti-misuse, not a security boundary**. When
 `PerHostProfileIsolation` is TRUE (the default), profile names are namespaced per
-host application, so two different applications that happen to use the same profile
-name do not accidentally end up sharing one profile. This is not a security boundary:
-it does not encrypt or ACL profile data, and applications that deliberately use the
-same host identity and profile name can still share a profile.
-
+host application, so two different host applications that use the same profile
+name do not accidentally end up sharing one profile. Here a "host application" is
+identified by its main executable file name (the same host identity WebView2 already
+derives to distinguish apps), compared case-insensitively. This is not a
+security boundary: it does not encrypt profile data or apply access control lists to
+it, the host identity is not authenticated, and applications that run from an
+executable with the same file name, or that deliberately use the same host identity and
+profile name, can still share a profile. 
 Because a cluster shares one browser process, environment-wide process diagnostics
 can expose frame names and last-committed URLs for frames owned by other hosts in the
 cluster. Cluster members must trust one another with this metadata.
+
+Joining a cluster is controlled only by the `Id`. In this initial version there is no
+authentication or admission control: any process running as the same user that supplies
+a matching `Id` (and resolves the same runtime) attaches to the cluster, and matching
+`Id` values are the only requirement to join. The runtime does not verify the identity
+of the joining host. Treat the `Id` as a shared capability agreed among cooperating
+hosts, and do not use a cluster to share data across trust boundaries. If it matters
+that untrusted code on the machine cannot join, choose an `Id` that such code cannot
+predict; the per-user cluster root still scopes clusters to a single user.
+
+A cluster is scoped to a single user and a single logon session: its user data folder
+lives under the user's profile, and its coordination objects live in the per-session
+`Local\` namespace. Sharing a cluster across different users or across different logon
+sessions is not supported. All cooperating hosts must also run at the same integrity
+level and elevation state as the host that established the cluster. A host at a
+different integrity level may be unable to open the cluster's coordination objects or
+connect to the shared browser process and will fail to join; mixing integrity levels or
+elevation among hosts is not supported and is not guaranteed to fail cleanly. This
+mirrors the existing guidance against sharing a single user data folder across
+elevation with `CreateCoreWebView2EnvironmentWithOptions`.
 
 # Examples
 
 ## Win32 C++
 
-The example shows the recommended "Get, then Create" flow: read the cluster's options
-for a well-known cluster id, reuse them if the cluster already exists, otherwise
+The example shows the recommended "Get, then create or join" flow: read the cluster's options
+for a well-known cluster ID, reuse them if the cluster already exists, otherwise
 offer your own; then create (which either establishes the cluster or attaches to one
 with matching options). On a mismatch, re-read the authoritative options and retry.
 
@@ -128,13 +167,15 @@ wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> BuildClusterOptions()
 
 void AppWindow::CreateSharedEnvironment()
 {
-    // Step 1 - synchronously ask what options the cluster already uses. No browser spawn.
+    // Step 1 - synchronously ask what options the cluster already uses. This call
+    // does not start a browser process.
     wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> existing;
     HRESULT hr = GetCoreWebView2ClusterEnvironmentOptions(kClusterId, &existing);
 
     // Step 2 - if a cluster already exists, decide whether its options are acceptable
-    // before attaching; if not, use a private environment. Offer my own options if no
-    // cluster exists yet, or go private if cluster environments are not supported here.
+    // before attaching; if not, use a private environment. Offer this host's options if no
+    // cluster exists yet, or use a private environment if cluster environments are
+    // not supported in this host.
     wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> options;
     if (SUCCEEDED(hr))
     {
@@ -151,8 +192,8 @@ void AppWindow::CreateSharedEnvironment()
     }
     else if (hr == HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED))
     {
-        // Sandboxed AppContainer process (for example a UWP app) that cannot
-        // share or access the cluster's user data folder.
+        // Sandboxed AppContainer process (for example, a UWP app) that cannot
+        // use cluster environments.
         UsePrivateEnvironment();
         return;
     }
@@ -162,13 +203,13 @@ void AppWindow::CreateSharedEnvironment()
         return;
     }
 
-    // Step 3 - same symmetric create either way: establishes, or attaches to a
+    // Step 3 - use the same create operation in either case: it establishes or attaches to a
     // cluster with matching options.
     CreateSharedEnvironmentWithOptions(options.get());
 }
 
 void AppWindow::CreateSharedEnvironmentWithOptions(
-    ICoreWebView2ClusterEnvironmentOptions* options)
+    ICoreWebView2ClusterEnvironmentOptions* options, bool allowRetry /* = true */)
 {
     HRESULT hr = CreateOrJoinCoreWebView2ClusterEnvironment(
         options,
@@ -176,10 +217,11 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
             [this](HRESULT errorCode,
                    ICoreWebView2ClusterEnvironmentCreateResult* result) -> HRESULT
             {
-                // A failing errorCode means the environment could not be created (for
-                // example the WebView2 Runtime could not be found). Handle it the same
-                // way as a failure from CreateCoreWebView2EnvironmentWithOptions (for
-                // example, surface an error and stop).
+                // A failing errorCode means the operation started but then failed
+                // (for example, the browser process could not be launched). Handle the
+                // creation failure the same way as a failure from
+                // CreateCoreWebView2EnvironmentWithOptions
+                // (for example, surface an error and stop).
                 CHECK_FAILURE(errorCode);
 
                 COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS status;
@@ -188,7 +230,7 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
                 {
                 case COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED:
                 {
-                    // Established the cluster, or attached to one with matching options.
+                    // Established the cluster or attached to one with matching options.
                     wil::com_ptr<ICoreWebView2Environment> environment;
                     CHECK_FAILURE(result->get_Environment(&environment));
                     OnSharedEnvironmentReady(environment.get());
@@ -197,14 +239,18 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
 
                 case COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH:
                 {
-                    // A live cluster has different options than mine. Re-read the
-                    // authoritative options and retry with them (or go private).
+                    // The live cluster's options differ from the requested options. Re-read the
+                    // authoritative options and retry once with them; if it still
+                    // does not work out, go private. Retrying only once (rather than
+                    // looping) bounds the work if the cluster keeps changing.
                     wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> authoritative;
-                    if (SUCCEEDED(GetCoreWebView2ClusterEnvironmentOptions(
+                    if (allowRetry &&
+                        SUCCEEDED(GetCoreWebView2ClusterEnvironmentOptions(
                             kClusterId, &authoritative)) &&
                         AcceptableForMe(authoritative.get()))
                     {
-                        CreateSharedEnvironmentWithOptions(authoritative.get());
+                        CreateSharedEnvironmentWithOptions(
+                            authoritative.get(), /*allowRetry=*/false);
                     }
                     else
                     {
@@ -219,8 +265,8 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
 
     if (hr == HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED))
     {
-        // This host cannot share or access the cluster's user data folder (for
-        // example a sandboxed AppContainer process such as a UWP app). Cluster
+        // This host cannot use cluster environments (for
+        // example, a sandboxed AppContainer process such as a UWP app). Cluster
         // environments are unavailable here; use a private environment instead.
         UsePrivateEnvironment();
         return;
@@ -249,14 +295,14 @@ async Task CreateSharedEnvironmentAsync()
 {
     try
     {
-        // Step 1 - read the cluster's options for this `Id`. No browser
-        // spawn. Returns null when no cluster exists yet.
+        // Step 1 - read the cluster's options for this `Id`. This call does not start a
+        // browser process. Returns null when no cluster exists yet.
         CoreWebView2ClusterEnvironmentOptions existing =
             CoreWebView2Environment.GetClusterEnvironmentOptions(ClusterId);
 
         // Step 2 - if a cluster already exists, decide whether its options are
-        // acceptable before attaching; if not, use a private environment. Offer my
-        // own options if no cluster exists yet.
+        // acceptable before attaching; if not, use a private environment. Offer this host's
+        // options if no cluster exists yet.
         if (existing != null && !AcceptableForMe(existing))
         {
             UsePrivateEnvironment();
@@ -264,8 +310,8 @@ async Task CreateSharedEnvironmentAsync()
         }
         CoreWebView2ClusterEnvironmentOptions options = existing ?? BuildClusterOptions();
 
-        // Step 3 - same symmetric create either way. If the environment cannot be
-        // created (for example the WebView2 Runtime could not be found, or cluster
+        // Step 3 - use the same create operation in either case. If the environment cannot be
+        // created (for example, the WebView2 Runtime could not be found, or cluster
         // environments are not supported in this host) the call throws, the same as
         // CreateAsync; the expected outcomes come back as Status.
         CoreWebView2ClusterEnvironmentCreateResult result =
@@ -273,20 +319,20 @@ async Task CreateSharedEnvironmentAsync()
 
         if (result.Status == CoreWebView2ClusterEnvironmentStatus.OptionsMismatch)
         {
-            // A live cluster has different options than ours. Re-read the
+            // The live cluster's options differ from the requested options. Re-read the
             // authoritative options and retry with them.
             CoreWebView2ClusterEnvironmentOptions authoritative =
                 CoreWebView2Environment.GetClusterEnvironmentOptions(ClusterId);
             if (authoritative != null && AcceptableForMe(authoritative))
             {
-                result =
-                    await CoreWebView2Environment.CreateOrJoinClusterEnvironmentAsync(authoritative);
+                result = await CoreWebView2Environment
+                    .CreateOrJoinClusterEnvironmentAsync(authoritative);
             }
         }
 
         if (result.Status == CoreWebView2ClusterEnvironmentStatus.Succeeded)
         {
-            // Established the cluster, or attached to one with matching options.
+            // Established the cluster or attached to one with matching options.
             OnSharedEnvironmentReady(result.Environment);
         }
         else
@@ -295,8 +341,8 @@ async Task CreateSharedEnvironmentAsync()
             UsePrivateEnvironment();
         }
     }
-    // HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED). This host cannot share or access the
-    // cluster's user data folder (for example a sandboxed AppContainer process
+    // HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED). This host cannot use cluster
+    // environments (for example, a sandboxed AppContainer process
     // such as a UWP app); use a private environment instead.
     catch (COMException ex) when (ex.HResult == unchecked((int)0x80070032))
     {
@@ -311,7 +357,7 @@ async Task CreateSharedEnvironmentAsync()
 
 ```cpp
 /// The outcome of `CreateOrJoinCoreWebView2ClusterEnvironment`, reported to the
-/// completion handler when its `errorCode` is `S_OK`.
+/// completion handler when `errorCode` is `S_OK`.
 [v1_enum] typedef enum COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS {
   /// The shared cluster environment is ready, either freshly established or attached
   /// to an existing cluster with matching options.
@@ -323,7 +369,7 @@ async Task CreateSharedEnvironmentAsync()
   COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH,
 } COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS;
 
-/// Establishes, or attaches to, the shared WebView2 cluster environment identified
+/// Establishes or attaches to the shared WebView2 cluster environment identified
 /// by the `Id` in `options`. If no cluster exists for the `Id`, this establishes
 /// one and the caller's options become the cluster's options. If a cluster already
 /// exists and the caller's options match it, the caller attaches to it. The outcome
@@ -331,16 +377,27 @@ async Task CreateSharedEnvironmentAsync()
 ///
 /// The return value reports whether `CreateOrJoinCoreWebView2ClusterEnvironment`
 /// could start:
-///   S_OK                                    -> started; `handler` will be invoked
-///                                              with the result.
-///   E_INVALIDARG                            -> `options` or its `Id` is invalid;
-///                                              `handler` is not invoked.
-///   HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) -> the host cannot share or access the
-///                                              cluster's user data folder (for
-///                                              example a sandboxed AppContainer
-///                                              process such as a UWP app); `handler`
-///                                              is not invoked.
+///   S_OK                                     -> started; `handler` will be invoked
+///                                               with the result.
+///   E_INVALIDARG                             -> `options` or its `Id` is invalid;
+///                                               `handler` is not invoked.
+///   HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)  -> the host cannot use cluster
+///                                               environments (for
+///                                               example, a sandboxed AppContainer
+///                                               process such as a UWP app); `handler`
+///                                               is not invoked.
+///   HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) -> no compatible WebView2 Runtime was
+///                                               found; `handler` is not invoked.
+/// Runtime discovery and compatibility failures are reported synchronously, before
+/// the operation starts, exactly as for `CreateCoreWebView2EnvironmentWithOptions`.
 /// When the return value is any failing `HRESULT`, `handler` is not invoked.
+///
+/// `handler` is invoked on the thread that called this function (which must pump a
+/// message loop), the same delivery model as `CreateCoreWebView2EnvironmentWithOptions`.
+/// Concurrent calls for the same `Id`, whether from this or another cooperating host,
+/// are serialized: the first to establish the cluster fixes its options, and each
+/// later call either attaches (matching options) or reports
+/// `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`.
 STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
     [in] ICoreWebView2ClusterEnvironmentOptions* options,
     [in] ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler* handler);
@@ -349,47 +406,59 @@ STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
 /// attaching to a cluster. A cluster exists only while its browser process is
 /// running. Returns `S_OK` and the cluster's options when a cluster is running for
 /// that `Id`, or `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)` and `nullptr` `options` when
-/// no cluster is running for that `Id`.
+/// no cluster is running for that `Id`. Returns `E_INVALIDARG` for an invalid `Id`.
+///
+/// The returned object is a detached snapshot of the cluster's options at the time
+/// of the call. Modifying it does not affect the running cluster; to change a
+/// cluster's options, all hosts must agree on the new set out of band.
 ///
 /// Returns `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)` and `nullptr` `options` in hosts
-/// that cannot share or access the cluster's user data folder, such as a sandboxed
-/// AppContainer process (for example a UWP app).
+/// that cannot use cluster environments, such as a sandboxed
+/// AppContainer process (for example, a UWP app).
 STDAPI GetCoreWebView2ClusterEnvironmentOptions(
     [in] LPCWSTR id,
     [out] ICoreWebView2ClusterEnvironmentOptions** options);
 
-/// The options used to establish or attach to a shared cluster environment.
+/// Provides the options used to establish or attach to a shared cluster environment.
 interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   /// The name that identifies the cluster. All cooperating hosts use the same
-  /// value. Use a stable, descriptive name your applications agree on (for example
+  /// value. Use a stable, descriptive name your applications agree on (for example,
   /// `"Contoso.Shell.Default"`); it does not need to be a GUID. Must not be `nullptr`
   /// or empty. The `Id` is case-insensitive and must be a valid file-system folder
-  /// name; otherwise the call fails with `E_INVALIDARG`.
+  /// name; otherwise the call fails with `E_INVALIDARG`. The returned string is
+  /// allocated with `CoTaskMemAlloc`; the caller must free it with `CoTaskMemFree`.
   [propget] HRESULT Id([out, retval] LPWSTR* id);
   /// Sets the `Id` property.
   [propput] HRESULT Id([in] LPCWSTR id);
 
-  /// Additional command-line switches passed to the shared browser process.
+  /// Specifies additional command-line switches to pass to the shared browser
+  /// process. The default is an empty string. The returned string is allocated with
+  /// `CoTaskMemAlloc`; the caller must free it with `CoTaskMemFree`.
   [propget] HRESULT AdditionalBrowserArguments([out, retval] LPWSTR* value);
   /// Sets the `AdditionalBrowserArguments` property.
   [propput] HRESULT AdditionalBrowserArguments([in] LPCWSTR value);
 
-  /// The default display language for the shared environment.
+  /// Specifies the default display language for the shared environment. The default
+  /// is the empty string (the runtime default). The returned string is allocated
+  /// with `CoTaskMemAlloc`; the caller must free it with `CoTaskMemFree`.
   [propget] HRESULT Language([out, retval] LPWSTR* value);
   /// Sets the `Language` property.
   [propput] HRESULT Language([in] LPCWSTR value);
 
-  /// Whether single sign-on using the OS primary account is allowed.
+  /// Indicates whether single sign-on using the OS primary account is allowed. The
+  /// default is `FALSE`.
   [propget] HRESULT AllowSingleSignOnUsingOSPrimaryAccount([out, retval] BOOL* value);
   /// Sets the `AllowSingleSignOnUsingOSPrimaryAccount` property.
   [propput] HRESULT AllowSingleSignOnUsingOSPrimaryAccount([in] BOOL value);
 
-  /// Whether tracking prevention is enabled for the shared environment.
+  /// Indicates whether tracking prevention is enabled for the shared environment.
+  /// The default is `TRUE`.
   [propget] HRESULT EnableTrackingPrevention([out, retval] BOOL* value);
   /// Sets the `EnableTrackingPrevention` property.
   [propput] HRESULT EnableTrackingPrevention([in] BOOL value);
 
-  /// Whether browser extensions are enabled for the shared environment.
+  /// Indicates whether browser extensions are enabled for the shared environment.
+  /// The default is `FALSE`.
   [propget] HRESULT AreBrowserExtensionsEnabled([out, retval] BOOL* value);
   /// Sets the `AreBrowserExtensionsEnabled` property.
   [propput] HRESULT AreBrowserExtensionsEnabled([in] BOOL value);
@@ -408,7 +477,7 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   /// Sets the `ReleaseChannels` property.
   [propput] HRESULT ReleaseChannels([in] COREWEBVIEW2_RELEASE_CHANNELS value);
 
-  /// The order that release channels are searched for during shared environment
+  /// The order in which release channels are searched during shared environment
   /// creation. The default is `COREWEBVIEW2_CHANNEL_SEARCH_KIND_MOST_STABLE`.
   [propget] HRESULT ChannelSearchKind([out, retval] COREWEBVIEW2_CHANNEL_SEARCH_KIND* value);
   /// Sets the `ChannelSearchKind` property.
@@ -426,15 +495,15 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
       [in] const ICoreWebView2CustomSchemeRegistration** schemeRegistrations);
 }
 
-/// The result of `CreateOrJoinCoreWebView2ClusterEnvironment`, provided to the
-/// completion handler when its `errorCode` is `S_OK`.
+/// Describes the result of `CreateOrJoinCoreWebView2ClusterEnvironment` that is
+/// provided to the completion handler when `errorCode` is `S_OK`.
 interface ICoreWebView2ClusterEnvironmentCreateResult : IUnknown {
-  /// The outcome of the create-or-join operation.
+  /// Indicates the outcome of the create-or-join operation.
   [propget] HRESULT Status(
       [out, retval] COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS* value);
 
-  /// The shared cluster environment. This is non-null only when `Status` is
-  /// `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED`; otherwise it is `nullptr`.
+  /// Gets the shared cluster environment. This is non-null only when `Status` is
+  /// `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED`; otherwise, it is `nullptr`.
   [propget] HRESULT Environment([out, retval] ICoreWebView2Environment** value);
 }
 
@@ -447,10 +516,12 @@ interface ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler : IUnknown
   ///    already exists for this `Id` with different options; `result.Environment`
   ///    is `nullptr`.
   ///
-  /// When `errorCode` is a failing `HRESULT`, the operation failed for another reason
-  /// and `result` is `nullptr`. This is the same set of failures that
-  /// `CreateCoreWebView2EnvironmentWithOptions` can report (for example, the WebView2
-  /// Runtime could not be found).
+  /// When `errorCode` is a failing `HRESULT`, the operation started but then failed
+  /// after start (for example, the browser process could not be launched), and
+  /// `result` is `nullptr`. Failures detected before the operation starts, such as an
+  /// invalid `Id` or a missing WebView2 Runtime, are reported through the synchronous
+  /// return value of `CreateOrJoinCoreWebView2ClusterEnvironment` and do not invoke
+  /// this handler.
   HRESULT Invoke(
       [in] HRESULT errorCode,
       [in] ICoreWebView2ClusterEnvironmentCreateResult* result);
@@ -459,15 +530,15 @@ interface ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler : IUnknown
 
 ## .NET/WinRT
 
-The two global functions are surfaced as static methods on `CoreWebView2Environment`,
+The two global functions are exposed as static methods on `CoreWebView2Environment`,
 mirroring how `CreateCoreWebView2EnvironmentWithOptions` maps to
 `CoreWebView2Environment.CreateAsync`. `CreateOrJoinClusterEnvironmentAsync` returns a
-`CoreWebView2ClusterEnvironmentCreateResult` carrying the `Status` and, on success,
-the `Environment`. When the operation cannot be started or fails, it throws; in
-particular a host that cannot share or access the cluster's user data folder (for
+`CoreWebView2ClusterEnvironmentCreateResult` that contains the `Status` and, on success,
+the `Environment`. When the operation cannot be started or fails, the method throws an exception; in
+particular a host that cannot use cluster environments (for
 example a sandboxed AppContainer process such as a UWP app) throws a
 `COMException` whose `HResult` is `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)`.
-`GetClusterEnvironmentOptions` returns `null` when no cluster exists for the id,
+`GetClusterEnvironmentOptions` returns `null` when no cluster exists for the ID,
 matching the `ERROR_NOT_FOUND` case of the COM API.
 
 ```c#
@@ -482,7 +553,7 @@ namespace Microsoft.Web.WebView2.Core
     runtimeclass CoreWebView2ClusterEnvironmentCreateResult
     {
         CoreWebView2ClusterEnvironmentStatus Status { get; };
-        // Non-null only when Status is Succeeded.
+        // Environment is non-null only when Status is Succeeded.
         CoreWebView2Environment Environment { get; };
     }
 
@@ -506,20 +577,20 @@ namespace Microsoft.Web.WebView2.Core
     {
         // ...
 
-        // Establishes, or attaches to, the shared cluster identified by options.Id.
+        // Establishes or attaches to the shared cluster identified by options.Id.
         // The result's Status reports the outcome (Succeeded or OptionsMismatch);
         // Environment is non-null only when Status is Succeeded. Throws when the
         // operation cannot be started or fails, including
-        // HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) when the host cannot share or
-        // access the cluster's user data folder (for example a sandboxed
-        // AppContainer process such as a UWP app).
+        // HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) when the host cannot use cluster
+        // environments (for example, a sandboxed AppContainer process such as a UWP
+        // app).
         static Windows.Foundation.IAsyncOperation<CoreWebView2ClusterEnvironmentCreateResult>
             CreateOrJoinClusterEnvironmentAsync(CoreWebView2ClusterEnvironmentOptions options);
 
         // Reads the options of the cluster identified by its Id. Returns
         // null when no cluster exists for that Id. Throws a COMException whose
         // HResult is HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) when the host cannot
-        // share or access the cluster's user data folder.
+        // use cluster environments.
         static CoreWebView2ClusterEnvironmentOptions GetClusterEnvironmentOptions(
             String id);
     }
@@ -530,8 +601,27 @@ namespace Microsoft.Web.WebView2.Core
 
 ## Relationship to existing options
 
-`ICoreWebView2ClusterEnvironmentOptions` is a new type rather than a reuse of
-`ICoreWebView2EnvironmentOptions`. Every option on it applies to the whole shared
-browser process, supplied by the first host to establish the cluster and shared by
-every host that attaches; there is no per-host override. The type intentionally
-exposes only a subset of the environment options.
+The proposal defines `ICoreWebView2ClusterEnvironmentOptions` as a new type instead of
+reusing `ICoreWebView2EnvironmentOptions`. `ICoreWebView2ClusterEnvironmentOptions`
+applies to the whole shared browser process. The first host to establish the cluster
+supplies the options, and every host that attaches shares them; there is no per-host
+override. The type intentionally exposes only a subset of the environment options.
+
+## Runtime selection and loader overrides
+
+Cluster environments locate a WebView2 Runtime through the same loader mechanism as
+`CreateCoreWebView2EnvironmentWithOptions`, including the existing loader overrides such
+as the `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER` environment variable and the corresponding
+registry override. This initial version does **not** coordinate those overrides across
+hosts. The cluster options do not capture them, they are not part of the options match,
+and the API does not detect or reconcile a difference between hosts.
+
+Because a WebView2 host loads a client DLL that must be the same version as the browser
+process it connects to, cooperating hosts must resolve the **same** runtime. The first
+host to establish the cluster launches the shared browser process from whatever runtime
+its loader resolved; a later host that resolves a different runtime (for example, because
+it has a loader override set that the first host did not) would load a mismatched client
+DLL and fail to attach cleanly to the running cluster. It is therefore the developer's
+responsibility to ensure every host that shares a cluster resolves the same runtime,
+ideally by not setting loader overrides for these apps, or by setting them identically
+across all cooperating hosts.

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -142,19 +142,25 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
     HRESULT hr = CreateOrJoinCoreWebView2ClusterEnvironment(
         options,
         Microsoft::WRL::Callback<ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler>(
-            [this](HRESULT errorCode, COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS status,
-                   ICoreWebView2Environment* environment) -> HRESULT
+            [this](HRESULT errorCode,
+                   ICoreWebView2ClusterEnvironmentCreateResult* result) -> HRESULT
             {
                 // A failing errorCode is an unexpected failure (for example the
                 // runtime could not be found). Handle it as usual.
                 CHECK_FAILURE(errorCode);
 
+                COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS status;
+                CHECK_FAILURE(result->get_Status(&status));
                 switch (status)
                 {
                 case COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED:
+                {
                     // Established the cluster, or attached to one with matching options.
-                    OnSharedEnvironmentReady(environment);
+                    wil::com_ptr<ICoreWebView2Environment> environment;
+                    CHECK_FAILURE(result->get_Environment(&environment));
+                    OnSharedEnvironmentReady(environment.get());
                     break;
+                }
 
                 case COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH:
                 {
@@ -227,7 +233,7 @@ async Task CreateSharedEnvironmentAsync()
         if (result.Status == CoreWebView2ClusterEnvironmentStatus.OptionsMismatch)
         {
             // A live cluster has different options than ours. Re-read the
-            // authoritative options and retry once with them.
+            // authoritative options and retry with them.
             CoreWebView2ClusterEnvironmentOptions authoritative =
                 CoreWebView2Environment.GetClusterEnvironmentOptions(ClusterId);
             if (authoritative != null && AcceptableForMe(authoritative))
@@ -365,21 +371,32 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
       [in] const ICoreWebView2CustomSchemeRegistration** schemeRegistrations);
 }
 
+/// The result of `CreateOrJoinCoreWebView2ClusterEnvironment`, provided to the
+/// completion handler when its `errorCode` is `S_OK`.
+interface ICoreWebView2ClusterEnvironmentCreateResult : IUnknown {
+  /// The outcome of the create-or-join operation.
+  [propget] HRESULT Status(
+      [out, retval] COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS* value);
+
+  /// The shared cluster environment. This is non-null only when `Status` is
+  /// `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED`; otherwise it is null.
+  [propget] HRESULT Environment([out, retval] ICoreWebView2Environment** value);
+}
+
 /// Receives the result of `CreateOrJoinCoreWebView2ClusterEnvironment`.
 interface ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler : IUnknown {
-  /// When `errorCode` is `S_OK`, `status` describes the outcome:
-  ///  * `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED` - `environment` is the
-  ///    shared cluster environment.
+  /// When `errorCode` is `S_OK`, `result` describes the outcome via its `Status`:
+  ///  * `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED` - `result.Environment`
+  ///    is the shared cluster environment.
   ///  * `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH` - a cluster
-  ///    already exists for this `Id` with different options; `environment` is null.
+  ///    already exists for this `Id` with different options; `result.Environment`
+  ///    is null.
   ///
   /// When `errorCode` is a failing `HRESULT`, the operation failed for another reason
-  /// (for example, the WebView2 Runtime could not be found), `status` is not
-  /// meaningful, and `environment` is null.
+  /// (for example, the WebView2 Runtime could not be found) and `result` is null.
   HRESULT Invoke(
       [in] HRESULT errorCode,
-      [in] COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS status,
-      [in] ICoreWebView2Environment* environment);
+      [in] ICoreWebView2ClusterEnvironmentCreateResult* result);
 }
 ```
 

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -31,9 +31,8 @@ This spec proposes the **symmetric create-or-join + synchronous `Get`** model:
   pre-flight: read what the cluster already uses, decide whether it likes it, then create.
 
 Sharing intent is expressed by an `Id` (a stable rendezvous name that all
-cooperating hosts agree on). The mapping from `Id` to on-disk UDF path is a fixed
-function, so the same `Id` always resolves to the same layout and first-creator-wins
-applies to the on-disk layout, not just to the live process.
+cooperating hosts agree on). The mapping from `Id` to on-disk user data folder is a
+fixed function, so the same `Id` always resolves to the same folder.
 
 # Conceptual pages (How To)
 
@@ -49,12 +48,10 @@ A cluster occupies its own user data folder namespace: it never joins or collide
 with an environment created by `CreateCoreWebView2EnvironmentWithOptions`.
 
 The **cluster options** are the `ICoreWebView2ClusterEnvironmentOptions` that the
-first host to establish the cluster supplied. Because a shared browser process is a
-single process-wide configuration, those options cannot differ per host, so the
-first establishing caller's set becomes authoritative for the lifetime of the
-cluster. Options that cannot be shared process-wide are intentionally absent from
-`ICoreWebView2ClusterEnvironmentOptions`.
-
+first host to establish the cluster supplied. They apply to the whole shared browser
+process and are shared by every host that attaches, so the first establishing
+caller's set is authoritative for the lifetime of the cluster; there is no per-host
+override. This type intentionally exposes only a subset of the environment options.
 The recommended usage pattern is **"Get, then Create"**:
 
 1. Synchronously `GetCoreWebView2ClusterEnvironmentOptions(id)` to see what options,
@@ -69,7 +66,9 @@ different options the instant after you read. The live browser stays authoritati
 so `Create` still validates and reports a status of
 `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH` if you lost the race, at
 which point you re-`Get` the now-authoritative options and retry, or fall back to a
-private (non-shared) environment.
+private environment. A private environment is an ordinary environment created with
+your own user data folder through `CreateCoreWebView2EnvironmentWithOptions`; it has
+its own separate data and does not share with the cluster.
 
 Profile isolation in a cluster is **anti-misuse, not a security boundary**. When
 `PerHostProfileIsolation` is TRUE (the default), profile names are namespaced per
@@ -472,8 +471,7 @@ namespace Microsoft.Web.WebView2.Core
 ## Relationship to existing options
 
 `ICoreWebView2ClusterEnvironmentOptions` is a new type rather than a reuse of
-`ICoreWebView2EnvironmentOptions`, so its surface exposes only the options that are
-meaningful for a shared cluster. Every option on it is process-wide: it takes a
-single value for the whole browser process, supplied by the first host to establish
-the cluster and shared by every host that attaches. There is no per-host override.
-
+`ICoreWebView2EnvironmentOptions`. Every option on it applies to the whole shared
+browser process, supplied by the first host to establish the cluster and shared by
+every host that attaches; there is no per-host override. The type intentionally
+exposes only a subset of the environment options.

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -360,10 +360,14 @@ namespace Microsoft.Web.WebView2.Core
 ## Relationship to existing options
 
 `ICoreWebView2ClusterEnvironmentOptions` is a new type rather than a reuse of
-`ICoreWebView2EnvironmentOptions`. It intentionally exposes only the options that can
-hold a single value across a shared browser process tree, plus the cluster `Id`.
-Options that cannot be shared process-wide (for example the remote-debugging port or
-logging, which the whole process can hold only one of) are omitted, so a host cannot
-set something on a cluster that would silently be ignored. The pinned set therefore
-belongs to the first creator and is not per host.
+`ICoreWebView2EnvironmentOptions`, so its surface exposes only the options that are
+meaningful for a shared cluster. Every option on it is process-wide: it takes a
+single value for the whole browser process, supplied by the first host to establish
+the cluster and shared by every host that attaches. There is no per-host override.
+
+This first iteration intentionally omits the options that select or locate the
+WebView2 Runtime itself, such as `BrowserExecutableFolder`,
+`TargetCompatibleBrowserVersion`, and the release-channel options (`ReleaseChannels`
+and `ChannelSearchKind`). These can be added later on a derived options interface
+without breaking compatibility.
 

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -68,6 +68,8 @@ Unlike `CreateCoreWebView2EnvironmentWithOptions`, you do **not** pass a user da
 folder. The runtime derives the folder from the `ClusterName`, so every host that uses
 the same `ClusterName` resolves to the same on-disk location. `ClusterName` comparison is
 case-insensitive, so `ClusterName` values that differ only in case refer to the same cluster.
+A different `ClusterName` gives a different cluster, with its own folder and its own
+browser process.
 The folder is created under a per-user cluster root,
 `%LOCALAPPDATA%\Microsoft\WebView2Clusters\<ClusterName>`, with the `ClusterName` as the leaf folder
 name (this is why the `ClusterName` must be a valid folder name). A cluster occupies its own
@@ -756,7 +758,7 @@ process it connects to, cooperating hosts must resolve the **same** runtime. The
 host to establish the cluster launches the shared browser process from whatever runtime
 its loader resolved; a later host that resolves a different runtime (for example, because
 it has a loader override set that the first host did not) would load a mismatched client
-DLL and fail to attach cleanly to the running cluster. It is therefore the developer's
+DLL and fail to join the running cluster. It is therefore the developer's
 responsibility to ensure every host that shares a cluster resolves the same runtime,
 ideally by not setting loader overrides for these apps, or by setting them identically
 across all cooperating hosts.

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -20,6 +20,12 @@ options up front. Cooperating host applications trust one
 another and agree on a shared `ClusterName` in advance; sharing is by convention, and
 the WebView2 Runtime does not restrict which applications may join a cluster.
 
+Cluster environments are intended for well coordinated applications that agree on the
+cluster name and options in advance, or that read the current options with
+`GetCoreWebView2ClusterEnvironmentOptions` before joining. They are not intended for
+loosely coupled applications that share a WebView2 environment without that
+coordination.
+
 This spec proposes a symmetric create-or-join model and a companion operation that reads a
 cluster's options:
 
@@ -46,10 +52,11 @@ those hosts agree on out of band. All hosts that establish a cluster with the sa
 
 Cluster environments are supported for standard desktop host processes: non-sandboxed,
 non-containerized applications running at medium or high integrity level. Applications
-that cannot create or share the cluster's per-user user data folder fail with
-`ERROR_NOT_SUPPORTED`. A transient failure to access an otherwise-supported cluster's
+that cannot create or share the cluster's per-user user data folder are reported with a
+status of `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_NOT_SUPPORTED` rather than as a
+failure of the call. A transient failure to access an otherwise-supported cluster's
 user data folder (for example, an access-denied or sharing violation) is not reported
-as `ERROR_NOT_SUPPORTED`; it surfaces as an ordinary create failure.
+that way; it surfaces as an ordinary create failure.
 
 These entry points exist only in WebView2 Runtime versions that implement them. On an
 older runtime they are unavailable, so a host should feature-detect the API using the
@@ -94,8 +101,9 @@ immediately after `Get` returns. The running browser process remains authoritati
 `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`, call
 `GetCoreWebView2ClusterEnvironmentOptions` again to read the authoritative options and
 retry, or fall back to a private environment. If
-`CreateOrJoinCoreWebView2ClusterEnvironment`
-fails with `ERROR_NOT_SUPPORTED` (this host cannot use a cluster environment), use a
+`CreateOrJoinCoreWebView2ClusterEnvironment` reports
+`COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_NOT_SUPPORTED` (this host cannot use a cluster
+environment), use a
 private environment. A private environment is an ordinary environment created with
 your own user data folder through `CreateCoreWebView2EnvironmentWithOptions`; it has
 its own data and does not share with the cluster.
@@ -109,9 +117,10 @@ comparison, so a host requesting a different channel than the running cluster re
 a mismatch. `ClusterName` identifies the cluster and is not part of this comparison.
 
 Profile isolation in a cluster is **anti-misuse, not a security boundary**. When
-`PerHostProfileIsolation` is TRUE (the default), profile names are namespaced per
-host application, so two different host applications that use the same profile
-name do not accidentally end up sharing one profile. Here a "host application" is
+`PerHostProfileIsolation` is TRUE (the default), the Edge browser profile names used
+within the cluster's shared user data folder are namespaced per host application, so
+two different host applications that use the same profile name do not accidentally end
+up sharing one profile. Here a "host application" is
 identified by its main executable file name (the same host identity WebView2 already
 derives to distinguish apps), compared case-insensitively. This is not a
 security boundary: it does not encrypt profile data or apply access control lists to
@@ -129,9 +138,9 @@ authentication or admission control: any process running as the same user that s
 a matching `ClusterName` (and resolves the same runtime) attaches to the cluster, and matching
 `ClusterName` values are the only requirement to join. The runtime does not verify the identity
 of the joining host. Treat the `ClusterName` as a shared capability agreed among cooperating
-hosts, and do not use a cluster to share data across trust boundaries. If it matters
-that untrusted code on the machine cannot join, choose a `ClusterName` that such code cannot
-predict; the per-user cluster root still scopes clusters to a single user.
+hosts, and do not use a cluster to share data across trust boundaries. The `ClusterName`
+is not a security boundary: cluster folders can be enumerated under the per-user cluster
+root, so choosing a less predictable name does not provide a meaningful security benefit.
 
 A cluster is scoped to a single user and a single logon session: its user data folder
 lives under the user's profile, and its coordination objects live in the per-session
@@ -157,6 +166,9 @@ with matching options). On a mismatch, re-read the authoritative options and ret
 // A stable rendezvous name that all cooperating hosts agree on.
 constexpr PCWSTR kClusterName = L"Contoso.Shell.Default";
 
+// The first WebView2 Runtime version that supports cluster environments.
+constexpr PCWSTR kMinClusterRuntimeVersion = L"1.0.9999.0";
+
 // Build the options this host would use if it is the first to establish the cluster.
 wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> BuildClusterOptions()
 {
@@ -169,41 +181,37 @@ wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> BuildClusterOptions()
 
 void AppWindow::CreateSharedEnvironment()
 {
-    // Step 1 - synchronously ask what options the cluster already uses. This call
-    // does not start a browser process.
-    wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> existing;
-    HRESULT hr = GetCoreWebView2ClusterEnvironmentOptions(kClusterName, &existing);
-
-    // Step 2 - if a cluster already exists, decide whether its options are acceptable
-    // before attaching; if not, use a private environment. Offer this host's options if no
-    // cluster exists yet, or use a private environment if cluster environments are
-    // not supported in this host.
-    wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> options;
-    if (SUCCEEDED(hr))
+    // Step 0 - check that the installed WebView2 Runtime is new enough to support
+    // cluster environments. If it is not, use a private environment.
+    wil::unique_cotaskmem_string availableVersion;
+    int versionComparison = 0;
+    if (FAILED(GetAvailableCoreWebView2BrowserVersionString(
+            nullptr, &availableVersion)) ||
+        FAILED(CompareBrowserVersions(
+            availableVersion.get(), kMinClusterRuntimeVersion,
+            &versionComparison)) ||
+        versionComparison < 0)
     {
-        if (!AcceptableForMe(existing.get()))
-        {
-            UsePrivateEnvironment();
-            return;
-        }
-        options = existing;
-    }
-    else if (hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND))
-    {
-        options = BuildClusterOptions();
-    }
-    else if (hr == HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED))
-    {
-        // Sandboxed AppContainer process (for example, a UWP app) that cannot
-        // use cluster environments.
         UsePrivateEnvironment();
         return;
     }
-    else
+
+    // Step 1 - synchronously ask what options the cluster already uses. This call
+    // does not start a browser process. `existing` is null when no cluster is
+    // running for this name, which is an expected result rather than an error.
+    wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> existing;
+    CHECK_FAILURE(GetCoreWebView2ClusterEnvironmentOptions(kClusterName, &existing));
+
+    // Step 2 - if a cluster already exists, decide whether its options are acceptable
+    // before attaching; if not, use a private environment. Offer this host's options if
+    // no cluster exists yet.
+    if (existing && !AcceptableForMe(existing.get()))
     {
-        CHECK_FAILURE(hr);
+        UsePrivateEnvironment();
         return;
     }
+    wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> options =
+        existing ? existing : BuildClusterOptions();
 
     // Step 3 - use the same create operation in either case: it establishes or attaches to a
     // cluster with matching options.
@@ -249,6 +257,7 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
                     if (allowRetry &&
                         SUCCEEDED(GetCoreWebView2ClusterEnvironmentOptions(
                             kClusterName, &authoritative)) &&
+                        authoritative &&
                         AcceptableForMe(authoritative.get()))
                     {
                         CreateSharedEnvironmentWithOptions(
@@ -260,19 +269,28 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
                     }
                     break;
                 }
+
+                case COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_NOT_SUPPORTED:
+                {
+                    // This host cannot use cluster environments, for example a
+                    // sandboxed AppContainer process such as a UWP app.
+                    UsePrivateEnvironment();
+                    break;
+                }
+
+                default:
+                {
+                    // Unknown status from a newer runtime; do not use clusters.
+                    UsePrivateEnvironment();
+                    break;
+                }
                 }
                 return S_OK;
             })
             .Get());
 
-    if (hr == HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED))
-    {
-        // This host cannot use cluster environments (for
-        // example, a sandboxed AppContainer process such as a UWP app). Cluster
-        // environments are unavailable here; use a private environment instead.
-        UsePrivateEnvironment();
-        return;
-    }
+    // Runtime discovery failures, such as no compatible WebView2 Runtime being
+    // installed, are reported synchronously here.
     CHECK_FAILURE(hr);
 }
 ```
@@ -282,6 +300,9 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
 ```c#
 // A stable rendezvous name that all cooperating hosts agree on.
 const string SharedClusterName = "Contoso.Shell.Default";
+
+// The first WebView2 Runtime version that supports cluster environments.
+const string MinClusterRuntimeVersion = "1.0.9999.0";
 
 CoreWebView2ClusterEnvironmentOptions BuildClusterOptions()
 {
@@ -295,34 +316,51 @@ CoreWebView2ClusterEnvironmentOptions BuildClusterOptions()
 
 async Task CreateSharedEnvironmentAsync()
 {
-    try
+    // Step 0 - check that the installed WebView2 Runtime is new enough to support
+    // cluster environments. If it is not, use a private environment.
+    string availableVersion = CoreWebView2Environment.GetAvailableBrowserVersionString();
+    if (availableVersion == null ||
+        CoreWebView2Environment.CompareBrowserVersions(
+            availableVersion, MinClusterRuntimeVersion) < 0)
     {
-        // Step 1 - read the cluster's options for this `ClusterName`. This call does not start a
-        // browser process. Returns null when no cluster exists yet.
-        CoreWebView2ClusterEnvironmentOptions existing =
-            CoreWebView2Environment.GetClusterEnvironmentOptions(SharedClusterName);
+        UsePrivateEnvironment();
+        return;
+    }
 
-        // Step 2 - if a cluster already exists, decide whether its options are
-        // acceptable before attaching; if not, use a private environment. Offer this host's
-        // options if no cluster exists yet.
-        if (existing != null && !AcceptableForMe(existing))
-        {
-            UsePrivateEnvironment();
-            return;
-        }
-        CoreWebView2ClusterEnvironmentOptions options = existing ?? BuildClusterOptions();
+    // Step 1 - read the cluster's options for this `ClusterName`. This call does not start a
+    // browser process. Returns null when no cluster exists yet.
+    CoreWebView2ClusterEnvironmentOptions existing =
+        CoreWebView2Environment.GetClusterEnvironmentOptions(SharedClusterName);
 
-        // Step 3 - use the same create operation in either case. If the environment cannot be
-        // created (for example, the WebView2 Runtime could not be found, or cluster
-        // environments are not supported in this host) the call throws, the same as
-        // CreateAsync; the expected outcomes come back as Status.
-        CoreWebView2ClusterEnvironmentCreateResult result =
-            await CoreWebView2Environment.CreateOrJoinClusterEnvironmentAsync(options);
+    // Step 2 - if a cluster already exists, decide whether its options are
+    // acceptable before attaching; if not, use a private environment. Offer this host's
+    // options if no cluster exists yet.
+    if (existing != null && !AcceptableForMe(existing))
+    {
+        UsePrivateEnvironment();
+        return;
+    }
+    CoreWebView2ClusterEnvironmentOptions options = existing ?? BuildClusterOptions();
 
-        if (result.Status == CoreWebView2ClusterEnvironmentStatus.OptionsMismatch)
-        {
-            // The live cluster's options differ from the requested options. Re-read the
-            // authoritative options and retry with them.
+    // Step 3 - use the same create operation in either case. The expected outcomes,
+    // including this host not being able to use cluster environments, come back as
+    // Status. Runtime discovery failures, such as no compatible WebView2 Runtime
+    // being installed, throw the same as CreateAsync.
+    CoreWebView2ClusterEnvironmentCreateResult result =
+        await CoreWebView2Environment.CreateOrJoinClusterEnvironmentAsync(options);
+
+    switch (result.Status)
+    {
+        case CoreWebView2ClusterEnvironmentStatus.Succeeded:
+            // Established the cluster or attached to one with matching options.
+            OnSharedEnvironmentReady(result.Environment);
+            break;
+
+        case CoreWebView2ClusterEnvironmentStatus.OptionsMismatch:
+            // The live cluster's options differ from the requested options. Re-read
+            // the authoritative options and retry once with them; if it still does
+            // not work out, go private. Retrying only once (rather than looping)
+            // bounds the work if the cluster keeps changing.
             CoreWebView2ClusterEnvironmentOptions authoritative =
                 CoreWebView2Environment.GetClusterEnvironmentOptions(SharedClusterName);
             if (authoritative != null && AcceptableForMe(authoritative))
@@ -330,25 +368,27 @@ async Task CreateSharedEnvironmentAsync()
                 result = await CoreWebView2Environment
                     .CreateOrJoinClusterEnvironmentAsync(authoritative);
             }
-        }
 
-        if (result.Status == CoreWebView2ClusterEnvironmentStatus.Succeeded)
-        {
-            // Established the cluster or attached to one with matching options.
-            OnSharedEnvironmentReady(result.Environment);
-        }
-        else
-        {
-            // Still mismatched after retrying; fall back to a private environment.
+            if (result.Status == CoreWebView2ClusterEnvironmentStatus.Succeeded)
+            {
+                OnSharedEnvironmentReady(result.Environment);
+            }
+            else
+            {
+                UsePrivateEnvironment();
+            }
+            break;
+
+        case CoreWebView2ClusterEnvironmentStatus.NotSupported:
+            // This host cannot use cluster environments, for example a sandboxed
+            // AppContainer process such as a UWP app.
             UsePrivateEnvironment();
-        }
-    }
-    // HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED). This host cannot use cluster
-    // environments (for example, a sandboxed AppContainer process
-    // such as a UWP app); use a private environment instead.
-    catch (COMException ex) when (ex.HResult == unchecked((int)0x80070032))
-    {
-        UsePrivateEnvironment();
+            break;
+
+        default:
+            // Unknown status from a newer runtime; do not use clusters.
+            UsePrivateEnvironment();
+            break;
     }
 }
 ```
@@ -445,6 +485,10 @@ void DeleteClusterUserDataFolderOnUninstall()
   /// `GetCoreWebView2ClusterEnvironmentOptions` and retry, or use a private
   /// (non-shared) environment.
   COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH,
+  /// This host cannot use cluster environments, for example a sandboxed
+  /// AppContainer process such as a UWP app. No environment is provided; use a
+  /// private (non-shared) environment instead.
+  COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_NOT_SUPPORTED,
 } COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS;
 
 /// Establishes or attaches to the shared WebView2 cluster environment identified
@@ -459,16 +503,16 @@ void DeleteClusterUserDataFolderOnUninstall()
 ///                                               with the result.
 ///   E_INVALIDARG                             -> `options` or its `ClusterName` is invalid;
 ///                                               `handler` is not invoked.
-///   HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)  -> the host cannot use cluster
-///                                               environments (for
-///                                               example, a sandboxed AppContainer
-///                                               process such as a UWP app); `handler`
-///                                               is not invoked.
 ///   HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) -> no compatible WebView2 Runtime was
 ///                                               found; `handler` is not invoked.
 /// Runtime discovery and compatibility failures are reported synchronously, before
 /// the operation starts, exactly as for `CreateCoreWebView2EnvironmentWithOptions`.
 /// When the return value is any failing `HRESULT`, `handler` is not invoked.
+///
+/// A host that cannot use cluster environments is not a failure of the call. The
+/// operation starts and `handler` is invoked with
+/// `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_NOT_SUPPORTED`, so a caller does not need
+/// to handle it as an error to use this API correctly.
 ///
 /// `handler` is invoked on the thread that called this function (which must pump a
 /// message loop), the same delivery model as `CreateCoreWebView2EnvironmentWithOptions`.
@@ -501,17 +545,17 @@ STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
 /// Reads the options of the cluster identified by its `ClusterName` without creating or
 /// attaching to a cluster. A cluster exists only while its browser process is
 /// running. Returns `S_OK` and the cluster's options when a cluster is running for
-/// that `ClusterName`, or `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)` and `nullptr` `options`
-/// when no cluster is running for that `ClusterName`. Returns `E_INVALIDARG` for an
-/// invalid `ClusterName`.
+/// that `ClusterName`, or `S_OK` and `nullptr` `options` when no cluster is running for
+/// that `ClusterName`. No cluster for a given `ClusterName` is an expected result rather
+/// than an error, so check `options` for `nullptr` instead of checking for a failing
+/// `HRESULT`. Returns `E_INVALIDARG` for an invalid `ClusterName`.
 ///
 /// The returned object is a detached snapshot of the cluster's options at the time
 /// of the call. Modifying it does not affect the running cluster; to change a
 /// cluster's options, all hosts must agree on the new set out of band.
 ///
-/// Returns `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)` and `nullptr` `options` in hosts
-/// that cannot use cluster environments, such as a sandboxed
-/// AppContainer process (for example, a UWP app).
+/// Also returns `S_OK` and `nullptr` `options` in hosts that cannot use cluster
+/// environments, such as a sandboxed AppContainer process (for example, a UWP app).
 STDAPI GetCoreWebView2ClusterEnvironmentOptions(
     [in] LPCWSTR clusterName,
     [out] ICoreWebView2ClusterEnvironmentOptions** options);
@@ -519,9 +563,13 @@ STDAPI GetCoreWebView2ClusterEnvironmentOptions(
 /// Provides the options used to establish or attach to a shared cluster environment.
 interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   /// The name that identifies the cluster. All cooperating hosts use the same
-  /// value. Use a stable, descriptive name your applications agree on (for example,
-  /// `"Contoso.Shell.Default"`); it does not need to be a GUID. Must not be `nullptr`
-  /// or empty. The `ClusterName` is case-insensitive and must be a valid file-system folder
+  /// value. Use a stable, descriptive name that your applications agree on in
+  /// advance. To avoid colliding with another application's cluster, include a name
+  /// you control, such as your company or product name, or a GUID. For example,
+  /// `"Contoso.Shell.Default"` or
+  /// `"{5E4A1C6E-9C7B-4C2B-8B1E-2F3A5D7C9E11}.Shell"`. Must not be `nullptr`
+  /// or empty. The `ClusterName` is case-insensitive, is limited to 128 characters,
+  /// and must be a valid file-system folder
   /// name; otherwise the call fails with `E_INVALIDARG`. The returned string is
   /// allocated with `CoTaskMemAlloc`; the caller must free it with `CoTaskMemFree`.
   [propget] HRESULT ClusterName([out, retval] LPWSTR* value);
@@ -631,12 +679,14 @@ The two global functions are exposed as static methods on `CoreWebView2Environme
 mirroring how `CreateCoreWebView2EnvironmentWithOptions` maps to
 `CoreWebView2Environment.CreateAsync`. `CreateOrJoinClusterEnvironmentAsync` returns a
 `CoreWebView2ClusterEnvironmentCreateResult` that contains the `Status` and, on success,
-the `Environment`. When the operation cannot be started or fails, the method throws an exception; in
-particular a host that cannot use cluster environments (for
-example, a sandboxed AppContainer process such as a UWP app) throws a
-`COMException` whose `HResult` is `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)`.
+the `Environment`. A host that cannot use cluster environments (for example, a sandboxed
+AppContainer process such as a UWP app) is reported as
+`CoreWebView2ClusterEnvironmentStatus.NotSupported` rather than as an exception, so
+minimal correct usage of this API does not require a `try`/`catch`. The method still
+throws when the operation cannot be started or fails after starting, for example when no
+compatible WebView2 Runtime is found, the same as `CreateAsync`.
 `GetClusterEnvironmentOptions` returns `null` when no cluster exists for the given
-`ClusterName`, matching the `ERROR_NOT_FOUND` case of the COM API.
+`ClusterName`, matching the COM API, which returns `S_OK` with `nullptr` options.
 
 ```c#
 namespace Microsoft.Web.WebView2.Core
@@ -645,6 +695,7 @@ namespace Microsoft.Web.WebView2.Core
     {
         Succeeded = 0,
         OptionsMismatch = 1,
+        NotSupported = 2,
     };
 
     runtimeclass CoreWebView2ClusterEnvironmentCreateResult
@@ -675,19 +726,17 @@ namespace Microsoft.Web.WebView2.Core
         // ...
 
         // Establishes or attaches to the shared cluster identified by options.ClusterName.
-        // The result's Status reports the outcome (Succeeded or OptionsMismatch);
-        // Environment is non-null only when Status is Succeeded. Throws when the
-        // operation cannot be started or fails, including
-        // HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) when the host cannot use cluster
-        // environments (for example, a sandboxed AppContainer process such as a UWP
-        // app).
+        // The result's Status reports the outcome (Succeeded, OptionsMismatch or
+        // NotSupported); Environment is non-null only when Status is Succeeded. A host
+        // that cannot use cluster environments is reported as NotSupported rather than
+        // as an exception. Throws when the operation cannot be started or fails after
+        // starting, for example when no compatible WebView2 Runtime is found.
         static Windows.Foundation.IAsyncOperation<CoreWebView2ClusterEnvironmentCreateResult>
             CreateOrJoinClusterEnvironmentAsync(CoreWebView2ClusterEnvironmentOptions options);
 
         // Reads the options of the cluster identified by its ClusterName. Returns
-        // null when no cluster exists for that ClusterName. Throws a COMException whose
-        // HResult is HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) when the host cannot
-        // use cluster environments.
+        // null when no cluster exists for that ClusterName, and also returns null in
+        // hosts that cannot use cluster environments.
         static CoreWebView2ClusterEnvironmentOptions GetClusterEnvironmentOptions(
             String clusterName);
     }

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -17,7 +17,7 @@ failure surfaces as a generic create error.
 We want a first-class, *explicit* way for a set of cooperating host applications to
 opt into one shared WebView2 environment—a "cluster"—and to agree on the shared
 options up front. Cooperating host applications trust one
-another and agree on a shared cluster `Id` in advance; sharing is by convention, and
+another and agree on a shared `ClusterName` in advance; sharing is by convention, and
 the WebView2 Runtime does not restrict which applications may join a cluster.
 
 This spec proposes a symmetric create-or-join model and a companion operation that reads a
@@ -25,24 +25,24 @@ cluster's options:
 
 - Every host calls the same symmetric `CreateOrJoinCoreWebView2ClusterEnvironment` with
   its full desired options. The **first** host to establish a cluster with a given
-  `Id` determines the cluster's options (first-creator-wins). A later host that passes
+  `ClusterName` determines the cluster's options. A later host that passes
   matching options attaches to the running cluster; a host that passes different
   options receives a completion status of
   `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`.
 - A separate `GetCoreWebView2ClusterEnvironmentOptions` reads the cluster's options
-  for an `Id` without launching the shared browser process, so a host can read a
+  for a `ClusterName` without launching the shared browser process, so a host can read a
   cluster's current options before the host calls the create-or-join operation.
 
-Sharing intent is expressed by an `Id` (a stable rendezvous name that all
-cooperating hosts agree on). The mapping from `Id` to on-disk user data folder is a
-fixed function, so the same `Id` always resolves to the same folder.
+Sharing intent is expressed by a `ClusterName` (a stable rendezvous name that all
+cooperating hosts agree on). The mapping from `ClusterName` to on-disk user data folder is a
+fixed function, so the same `ClusterName` always resolves to the same folder.
 
 # Description
 
 A **cluster environment** is a WebView2 environment that a group of cooperating
-host applications deliberately share, identified by a well-known `Id` string that
+host applications deliberately share, identified by a well-known `ClusterName` string that
 those hosts agree on out of band. All hosts that establish a cluster with the same
-`Id` run inside one shared browser process and one on-disk user data folder.
+`ClusterName` run inside one shared browser process and one on-disk user data folder.
 
 A host process must be able to create and share the cluster's per-user user data
 folder. A host that cannot, such as a sandboxed AppContainer process (for example, a
@@ -57,12 +57,12 @@ standard WebView2 versioning guidance and fall back to a private environment whe
 is absent.
 
 Unlike `CreateCoreWebView2EnvironmentWithOptions`, you do **not** pass a user data
-folder. The runtime derives the folder from the cluster `Id`, so every host that uses
-the same `Id` resolves to the same on-disk location. `Id` comparison is
-case-insensitive, so `Id` values that differ only in case refer to the same cluster.
+folder. The runtime derives the folder from the `ClusterName`, so every host that uses
+the same `ClusterName` resolves to the same on-disk location. `ClusterName` comparison is
+case-insensitive, so `ClusterName` values that differ only in case refer to the same cluster.
 The folder is created under a per-user cluster root,
-`%LOCALAPPDATA%\Microsoft\WebView2Clusters\<Id>`, with the `Id` as the leaf folder
-name (this is why the `Id` must be a valid folder name). A cluster occupies its own
+`%LOCALAPPDATA%\Microsoft\WebView2Clusters\<ClusterName>`, with the `ClusterName` as the leaf folder
+name (this is why the `ClusterName` must be a valid folder name). A cluster occupies its own
 user data folder namespace: folders under this root are reachable only through the
 cluster API. Even if a caller passes a cluster folder path explicitly to
 `CreateCoreWebView2EnvironmentWithOptions`, that call is rejected and does not join the
@@ -80,7 +80,7 @@ exposes only a subset of the environment options.
 
 The recommended usage pattern is **"Get, then create or join"**:
 
-1. Call `GetCoreWebView2ClusterEnvironmentOptions(id)` to see what options, if any,
+1. Call `GetCoreWebView2ClusterEnvironmentOptions(clusterName)` to see what options, if any,
    the cluster already uses. This does not launch the shared browser process.
 2. If a cluster already exists, reuse its options and attach to it. If none exists
    yet, provide your own options, which become the cluster's options.
@@ -101,12 +101,12 @@ your own user data folder through `CreateCoreWebView2EnvironmentWithOptions`; it
 its own data and does not share with the cluster.
 
 Options **match** when every option on `ICoreWebView2ClusterEnvironmentOptions`
-except `Id` is equal: each scalar and boolean option is equal, `AdditionalBrowserArguments`
+except `ClusterName` is equal: each scalar and boolean option is equal, `AdditionalBrowserArguments`
 is the same string (compared exactly, with no normalization of whitespace or switch
 order), and the custom scheme registrations are the same in the same order. The
 release-channel options (`ReleaseChannels` and `ChannelSearchKind`) are part of this
 comparison, so a host requesting a different channel than the running cluster receives
-a mismatch. `Id` identifies the cluster and is not part of this comparison.
+a mismatch. `ClusterName` identifies the cluster and is not part of this comparison.
 
 Profile isolation in a cluster is **anti-misuse, not a security boundary**. When
 `PerHostProfileIsolation` is TRUE (the default), profile names are namespaced per
@@ -117,18 +117,20 @@ derives to distinguish apps), compared case-insensitively. This is not a
 security boundary: it does not encrypt profile data or apply access control lists to
 it, the host identity is not authenticated, and applications that run from an
 executable with the same file name, or that deliberately use the same host identity and
-profile name, can still share a profile. 
+profile name, can still share a profile. Do not rely on it to isolate mutually
+distrusting code.
+
 Because a cluster shares one browser process, environment-wide process diagnostics
 can expose frame names and last-committed URLs for frames owned by other hosts in the
 cluster. Cluster members must trust one another with this metadata.
 
-Joining a cluster is controlled only by the `Id`. In this initial version there is no
+Joining a cluster is controlled only by the `ClusterName`. In this initial version there is no
 authentication or admission control: any process running as the same user that supplies
-a matching `Id` (and resolves the same runtime) attaches to the cluster, and matching
-`Id` values are the only requirement to join. The runtime does not verify the identity
-of the joining host. Treat the `Id` as a shared capability agreed among cooperating
+a matching `ClusterName` (and resolves the same runtime) attaches to the cluster, and matching
+`ClusterName` values are the only requirement to join. The runtime does not verify the identity
+of the joining host. Treat the `ClusterName` as a shared capability agreed among cooperating
 hosts, and do not use a cluster to share data across trust boundaries. If it matters
-that untrusted code on the machine cannot join, choose an `Id` that such code cannot
+that untrusted code on the machine cannot join, choose a `ClusterName` that such code cannot
 predict; the per-user cluster root still scopes clusters to a single user.
 
 A cluster is scoped to a single user and a single logon session: its user data folder
@@ -147,19 +149,19 @@ elevation with `CreateCoreWebView2EnvironmentWithOptions`.
 ## Win32 C++
 
 The example shows the recommended "Get, then create or join" flow: read the cluster's options
-for a well-known cluster ID, reuse them if the cluster already exists, otherwise
+for a well-known cluster name, reuse them if the cluster already exists, otherwise
 offer your own; then create (which either establishes the cluster or attaches to one
 with matching options). On a mismatch, re-read the authoritative options and retry.
 
 ```cpp
 // A stable rendezvous name that all cooperating hosts agree on.
-constexpr PCWSTR kClusterId = L"Contoso.Shell.Default";
+constexpr PCWSTR kClusterName = L"Contoso.Shell.Default";
 
 // Build the options this host would use if it is the first to establish the cluster.
 wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> BuildClusterOptions()
 {
     auto options = Microsoft::WRL::Make<CoreWebView2ClusterEnvironmentOptions>();
-    CHECK_FAILURE(options->put_Id(kClusterId));
+    CHECK_FAILURE(options->put_ClusterName(kClusterName));
     CHECK_FAILURE(options->put_Language(L"en-US"));
     CHECK_FAILURE(options->put_AreBrowserExtensionsEnabled(FALSE));
     return options;
@@ -170,7 +172,7 @@ void AppWindow::CreateSharedEnvironment()
     // Step 1 - synchronously ask what options the cluster already uses. This call
     // does not start a browser process.
     wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> existing;
-    HRESULT hr = GetCoreWebView2ClusterEnvironmentOptions(kClusterId, &existing);
+    HRESULT hr = GetCoreWebView2ClusterEnvironmentOptions(kClusterName, &existing);
 
     // Step 2 - if a cluster already exists, decide whether its options are acceptable
     // before attaching; if not, use a private environment. Offer this host's options if no
@@ -246,7 +248,7 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
                     wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> authoritative;
                     if (allowRetry &&
                         SUCCEEDED(GetCoreWebView2ClusterEnvironmentOptions(
-                            kClusterId, &authoritative)) &&
+                            kClusterName, &authoritative)) &&
                         AcceptableForMe(authoritative.get()))
                     {
                         CreateSharedEnvironmentWithOptions(
@@ -279,13 +281,13 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
 
 ```c#
 // A stable rendezvous name that all cooperating hosts agree on.
-const string ClusterId = "Contoso.Shell.Default";
+const string SharedClusterName = "Contoso.Shell.Default";
 
 CoreWebView2ClusterEnvironmentOptions BuildClusterOptions()
 {
     return new CoreWebView2ClusterEnvironmentOptions()
     {
-        Id = ClusterId,
+        ClusterName = SharedClusterName,
         Language = "en-US",
         AreBrowserExtensionsEnabled = false,
     };
@@ -295,10 +297,10 @@ async Task CreateSharedEnvironmentAsync()
 {
     try
     {
-        // Step 1 - read the cluster's options for this `Id`. This call does not start a
+        // Step 1 - read the cluster's options for this `ClusterName`. This call does not start a
         // browser process. Returns null when no cluster exists yet.
         CoreWebView2ClusterEnvironmentOptions existing =
-            CoreWebView2Environment.GetClusterEnvironmentOptions(ClusterId);
+            CoreWebView2Environment.GetClusterEnvironmentOptions(SharedClusterName);
 
         // Step 2 - if a cluster already exists, decide whether its options are
         // acceptable before attaching; if not, use a private environment. Offer this host's
@@ -322,7 +324,7 @@ async Task CreateSharedEnvironmentAsync()
             // The live cluster's options differ from the requested options. Re-read the
             // authoritative options and retry with them.
             CoreWebView2ClusterEnvironmentOptions authoritative =
-                CoreWebView2Environment.GetClusterEnvironmentOptions(ClusterId);
+                CoreWebView2Environment.GetClusterEnvironmentOptions(SharedClusterName);
             if (authoritative != null && AcceptableForMe(authoritative))
             {
                 result = await CoreWebView2Environment
@@ -362,7 +364,7 @@ async Task CreateSharedEnvironmentAsync()
   /// The shared cluster environment is ready, either freshly established or attached
   /// to an existing cluster with matching options.
   COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED,
-  /// A cluster already exists for this `Id` with different options. No environment is
+  /// A cluster already exists for this `ClusterName` with different options. No environment is
   /// provided; read the cluster's options with
   /// `GetCoreWebView2ClusterEnvironmentOptions` and retry, or use a private
   /// (non-shared) environment.
@@ -370,7 +372,7 @@ async Task CreateSharedEnvironmentAsync()
 } COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS;
 
 /// Establishes or attaches to the shared WebView2 cluster environment identified
-/// by the `Id` in `options`. If no cluster exists for the `Id`, this establishes
+/// by the `ClusterName` in `options`. If no cluster exists for the `ClusterName`, this establishes
 /// one and the caller's options become the cluster's options. If a cluster already
 /// exists and the caller's options match it, the caller attaches to it. The outcome
 /// is reported to `handler` as a `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS`.
@@ -379,7 +381,7 @@ async Task CreateSharedEnvironmentAsync()
 /// could start:
 ///   S_OK                                     -> started; `handler` will be invoked
 ///                                               with the result.
-///   E_INVALIDARG                             -> `options` or its `Id` is invalid;
+///   E_INVALIDARG                             -> `options` or its `ClusterName` is invalid;
 ///                                               `handler` is not invoked.
 ///   HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)  -> the host cannot use cluster
 ///                                               environments (for
@@ -394,7 +396,7 @@ async Task CreateSharedEnvironmentAsync()
 ///
 /// `handler` is invoked on the thread that called this function (which must pump a
 /// message loop), the same delivery model as `CreateCoreWebView2EnvironmentWithOptions`.
-/// Concurrent calls for the same `Id`, whether from this or another cooperating host,
+/// Concurrent calls for the same `ClusterName`, whether from this or another cooperating host,
 /// are serialized: the first to establish the cluster fixes its options, and each
 /// later call either attaches (matching options) or reports
 /// `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`.
@@ -402,11 +404,12 @@ STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
     [in] ICoreWebView2ClusterEnvironmentOptions* options,
     [in] ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler* handler);
 
-/// Reads the options of the cluster identified by its `Id` without creating or
+/// Reads the options of the cluster identified by its `ClusterName` without creating or
 /// attaching to a cluster. A cluster exists only while its browser process is
 /// running. Returns `S_OK` and the cluster's options when a cluster is running for
-/// that `Id`, or `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)` and `nullptr` `options` when
-/// no cluster is running for that `Id`. Returns `E_INVALIDARG` for an invalid `Id`.
+/// that `ClusterName`, or `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)` and `nullptr` `options`
+/// when no cluster is running for that `ClusterName`. Returns `E_INVALIDARG` for an
+/// invalid `ClusterName`.
 ///
 /// The returned object is a detached snapshot of the cluster's options at the time
 /// of the call. Modifying it does not affect the running cluster; to change a
@@ -416,7 +419,7 @@ STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
 /// that cannot use cluster environments, such as a sandboxed
 /// AppContainer process (for example, a UWP app).
 STDAPI GetCoreWebView2ClusterEnvironmentOptions(
-    [in] LPCWSTR id,
+    [in] LPCWSTR clusterName,
     [out] ICoreWebView2ClusterEnvironmentOptions** options);
 
 /// Provides the options used to establish or attach to a shared cluster environment.
@@ -424,12 +427,12 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   /// The name that identifies the cluster. All cooperating hosts use the same
   /// value. Use a stable, descriptive name your applications agree on (for example,
   /// `"Contoso.Shell.Default"`); it does not need to be a GUID. Must not be `nullptr`
-  /// or empty. The `Id` is case-insensitive and must be a valid file-system folder
+  /// or empty. The `ClusterName` is case-insensitive and must be a valid file-system folder
   /// name; otherwise the call fails with `E_INVALIDARG`. The returned string is
   /// allocated with `CoTaskMemAlloc`; the caller must free it with `CoTaskMemFree`.
-  [propget] HRESULT Id([out, retval] LPWSTR* id);
-  /// Sets the `Id` property.
-  [propput] HRESULT Id([in] LPCWSTR id);
+  [propget] HRESULT ClusterName([out, retval] LPWSTR* value);
+  /// Sets the `ClusterName` property.
+  [propput] HRESULT ClusterName([in] LPCWSTR value);
 
   /// Specifies additional command-line switches to pass to the shared browser
   /// process. The default is an empty string. The returned string is allocated with
@@ -513,13 +516,13 @@ interface ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler : IUnknown
   ///  * `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED` - `result.Environment`
   ///    is the shared cluster environment.
   ///  * `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH` - a cluster
-  ///    already exists for this `Id` with different options; `result.Environment`
+  ///    already exists for this `ClusterName` with different options; `result.Environment`
   ///    is `nullptr`.
   ///
   /// When `errorCode` is a failing `HRESULT`, the operation started but then failed
   /// after start (for example, the browser process could not be launched), and
   /// `result` is `nullptr`. Failures detected before the operation starts, such as an
-  /// invalid `Id` or a missing WebView2 Runtime, are reported through the synchronous
+  /// invalid `ClusterName` or a missing WebView2 Runtime, are reported through the synchronous
   /// return value of `CreateOrJoinCoreWebView2ClusterEnvironment` and do not invoke
   /// this handler.
   HRESULT Invoke(
@@ -536,10 +539,10 @@ mirroring how `CreateCoreWebView2EnvironmentWithOptions` maps to
 `CoreWebView2ClusterEnvironmentCreateResult` that contains the `Status` and, on success,
 the `Environment`. When the operation cannot be started or fails, the method throws an exception; in
 particular a host that cannot use cluster environments (for
-example a sandboxed AppContainer process such as a UWP app) throws a
+example, a sandboxed AppContainer process such as a UWP app) throws a
 `COMException` whose `HResult` is `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)`.
-`GetClusterEnvironmentOptions` returns `null` when no cluster exists for the ID,
-matching the `ERROR_NOT_FOUND` case of the COM API.
+`GetClusterEnvironmentOptions` returns `null` when no cluster exists for the given
+`ClusterName`, matching the `ERROR_NOT_FOUND` case of the COM API.
 
 ```c#
 namespace Microsoft.Web.WebView2.Core
@@ -561,7 +564,7 @@ namespace Microsoft.Web.WebView2.Core
     {
         CoreWebView2ClusterEnvironmentOptions();
 
-        String Id { get; set; };
+        String ClusterName { get; set; };
         String AdditionalBrowserArguments { get; set; };
         String Language { get; set; };
         Boolean AllowSingleSignOnUsingOSPrimaryAccount { get; set; };
@@ -577,7 +580,7 @@ namespace Microsoft.Web.WebView2.Core
     {
         // ...
 
-        // Establishes or attaches to the shared cluster identified by options.Id.
+        // Establishes or attaches to the shared cluster identified by options.ClusterName.
         // The result's Status reports the outcome (Succeeded or OptionsMismatch);
         // Environment is non-null only when Status is Succeeded. Throws when the
         // operation cannot be started or fails, including
@@ -587,12 +590,12 @@ namespace Microsoft.Web.WebView2.Core
         static Windows.Foundation.IAsyncOperation<CoreWebView2ClusterEnvironmentCreateResult>
             CreateOrJoinClusterEnvironmentAsync(CoreWebView2ClusterEnvironmentOptions options);
 
-        // Reads the options of the cluster identified by its Id. Returns
-        // null when no cluster exists for that Id. Throws a COMException whose
+        // Reads the options of the cluster identified by its ClusterName. Returns
+        // null when no cluster exists for that ClusterName. Throws a COMException whose
         // HResult is HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) when the host cannot
         // use cluster environments.
         static CoreWebView2ClusterEnvironmentOptions GetClusterEnvironmentOptions(
-            String id);
+            String clusterName);
     }
 }
 ```

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -243,7 +243,7 @@ STDAPI CreateCoreWebView2ClusterEnvironment(
 /// State: the pinned options are persisted per cluster `Id` in the user data folder
 /// resolved from that `Id` (a per-`Id` record). The record survives after the
 /// cluster's browser process exits, so `Get` answers whether or not the cluster is
-/// currently running. See the Appendix for storage and lifetime details.
+/// currently running. See the Appendix for the full behavior guarantees.
 STDAPI GetCoreWebView2ClusterEnvironmentOptions(
     [in] LPCWSTR id,
     [out] ICoreWebView2ClusterEnvironmentOptions** options);
@@ -381,61 +381,36 @@ namespace Microsoft.Web.WebView2.Core
 
 # Appendix
 
-## Storage, concurrency, and lifetime
+## Behavior guarantees
 
-The pinned set lives in a per-`Id` record (for example a registry key such as
-`HKCU\Software\Microsoft\WebView2\SharedClusters\<Id>`) holding the serialized
-options plus the resolved UDF path. There is one named lock per cluster `Id`, and
-any host takes it while it establishes or attaches. The write happens inside the
-establish lock, only after the internal create succeeds:
+The following are the observable guarantees a caller can rely on; the storage and
+locking that back them are runtime implementation details.
 
-```text
-AcquireLock(Id)
-hr = <internal establish env for UDF(Id)>
-if SUCCEEDED(hr): WriteRecord(Id, options)   // still holding the lock
-ReleaseLock(Id)
-```
-
-Because both the create (which writes the pinned options) and `Get` (which reads
-them) coordinate through the same lock and record writes are atomic, a reader never
-sees a half-written set, and two creates racing when nothing exists yet cannot
-collide. Writing the caller's own options is authoritative because strict-equality
-means a success is either a fresh establish (this caller's options become the pinned
-set) or an attach whose options already equal the pinned set. The **live browser
-stays authoritative** on conflict, so a stale or missing record is self-healing: the
-next create attaches if options match, or returns
-`ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH` to re-read and retry. Lock acquisition
-must handle `WAIT_ABANDONED` so a crash while holding the lock does not wedge the
-next host.
-
-The per-`Id` record is kept as the forward-stable pinned set after the browser
-exits (it is a harmless, replayable recipe), which lets `Get` answer even when no
-browser is running. The pinned options a `Get` reads are configuration values, not
-liveness: the create path still decides liveness on the UDF, attaching if a shared
-browser is running and relaunching with the same options if the last host has
-exited. Nothing needs a background sweep.
+- **First-creator-wins.** The first host to establish a cluster for an `Id` pins its
+  options. A later host with an identical set attaches; a host with a different set
+  gets `ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH`.
+- **`Get` works whether or not the cluster is running.** The pinned set is remembered
+  for the `Id` after the cluster's browser exits, so `Get` can answer with no browser
+  spawned. `Get` reads configuration, not liveness.
+- **The live cluster is authoritative.** `Get` is only a hint and can race; `Create`
+  validates against the running cluster, so a stale or absent pinned set is
+  self-healing (the next `Create` attaches if options match, or returns
+  `OPTIONS_MISMATCH` to re-read and retry). Concurrent creates never observe a
+  partially-established cluster or a half-written option set. Nothing needs a
+  background sweep.
 
 ## Alternatives considered
 
 Two other API shapes were evaluated and rejected in favor of this one.
 
-**A. Create / Join role split.** One host `Create`s the cluster and pins options;
-everyone else `Join`s by name, passing no options, and `Join` hands back both the
-environment and the pinned options (so "learn the options" needs no separate read).
-Cleaner asymmetry, but it introduces a bootstrap race: if two hosts `Join` before
-anyone `Create`s, both get `NOT_FOUND` and need an extra rule (a designated creator,
-a `JoinOrCreate`, or bounded retry). The symmetric model in this spec avoids the
-"who creates first" race because every host runs the same create.
-
-**B. One synchronous getter, nothing else.** No cluster API at all: keep today's
-UDF-based sharing and only add
-`GetCoreWebView2EnvironmentOptions(userDataFolder, out options)` so a joiner can
-look before it leaps. Smallest possible surface and zero create-path change, but it
-does the least: attach still goes through today's create path and its existing
-errors, there is no named rendezvous, and there is no real "establish" step the
-runtime can guard with a lock. This spec's model was chosen because it makes shared
-behavior explicit and gives the runtime a lockable establish step; the getter-only
-shape remains a viable smaller-surface fallback if scope tightens.
+- **Create / Join role split.** One host `Create`s and pins options; others `Join` by
+  name and get the pinned set back. Cleaner asymmetry, but it has a bootstrap race
+  (two hosts `Join`ing before anyone `Create`s both get `NOT_FOUND`, needing an extra
+  rule). The symmetric model here avoids that because every host runs the same create.
+- **One synchronous getter, nothing else.** Keep today's UDF-based sharing and only add
+  a `Get` so a joiner can look before it leaps. Smallest surface, but no named
+  rendezvous and no lockable "establish" step. This model was chosen because it makes
+  sharing explicit; the getter-only shape remains a smaller-surface fallback.
 
 ## Why these options are process-wide
 

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -1,0 +1,461 @@
+Shared WebView2 Cluster Environment
+===
+
+# Background
+
+Today an application gets a WebView2 by calling
+[`CreateCoreWebView2EnvironmentWithOptions`](https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions)
+and passing a `UserDataFolder` (UDF). Two hosts that pass the *same* UDF already
+share a single browser process tree, which is how multiple WebView2 hosts save
+memory today. But that sharing is implicit: it is keyed entirely on the UDF path,
+the first launcher silently pins the environment options for everyone else, and a
+second host has no way to learn what those pinned options are before it attaches.
+If the second host's options disagree with the pinned set, it only finds out after
+it has already paid to launch, and the failure surfaces as a generic create error.
+
+We want a first-class, *explicit* way for a set of cooperating host apps (for
+example, a shell and the widgets it hosts) to opt into one shared WebView2 browser
+process tree — a "cluster" — and to negotiate the shared options up front rather
+than by accident.
+
+This spec proposes the **symmetric `Create` + synchronous `Get`** model:
+
+- Every host calls the same symmetric `CreateCoreWebView2ClusterEnvironment` with
+  its full desired options. The **first** host to establish a cluster with a given
+  `Id` pins its options (first-creator-wins). A later host that passes an identical
+  set attaches to the running cluster; a host that passes a different set gets a
+  typed `ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH`.
+- A separate **synchronous** `GetCoreWebView2ClusterEnvironmentOptions` reads the
+  pinned set back for an `Id` without spawning a browser, so a host can pre-flight:
+  read what is already pinned, decide whether it likes it, then create.
+
+Sharing intent is expressed by an `Id` (a stable rendezvous name that all
+cooperating hosts agree on). The mapping from `Id` to on-disk UDF path is a fixed
+function, so the same `Id` always resolves to the same layout and first-creator-wins
+applies to the on-disk layout, not just to the live process.
+
+This spec covers the **public API surface only**; storage, locking, and process
+management are implementation details summarized in the Appendix. Two alternative
+shapes that were considered (a `Create`/`Join` role split, and a single synchronous
+getter keyed on today's UDF) are described in the Appendix for reviewer context.
+
+# Conceptual pages (How To)
+
+_(This is conceptual documentation that will go to learn.microsoft.com "how to" page)_
+
+A **cluster environment** is a WebView2 environment that a group of cooperating
+host applications deliberately share, identified by a well-known `Id` string that
+those hosts agree on out of band (for example a constant in a shared header). All
+hosts that establish a cluster with the same `Id` run inside one browser process
+tree and one on-disk user data folder.
+
+The **pinned options** are the `ICoreWebView2ClusterEnvironmentOptions` that the
+first host to establish the cluster supplied. Because a browser process tree is a
+single process-wide configuration, those options cannot differ per host, so the
+first establishing caller's set becomes authoritative for the lifetime of the
+cluster. Options that cannot be shared process-wide are intentionally absent from
+`ICoreWebView2ClusterEnvironmentOptions`.
+
+The recommended usage pattern is **"Get, then Create"**:
+
+1. Synchronously `GetCoreWebView2ClusterEnvironmentOptions(id)` to see what, if
+   anything, is already pinned. This does not launch a browser.
+2. If something is pinned, reuse it (attach). If nothing is pinned yet, offer your
+   own options (you become the pinner).
+3. Call `CreateCoreWebView2ClusterEnvironment` with the chosen options. You either
+   establish the cluster or attach to an identical one.
+
+`Get` is only a hint: it can race with another host that pins a different set the
+instant after you read. The live browser stays authoritative, so `Create` still
+validates and returns `ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH` if you lost the
+race, at which point you re-`Get` the now-authoritative options and retry, or fall
+back to a private (non-shared) environment.
+
+Profile isolation in a cluster is **anti-misuse, not a security boundary**. The
+`PerExeProfileIsolation` option prevents *accidental* cross-app profile use; it does
+not encrypt or ACL profile data. Any app that knows the cluster `Id` and profile
+name can use a shared profile.
+
+# Examples
+
+## Win32 C++
+
+The example shows the recommended "Get, then Create" flow: read the pinned options
+for a well-known cluster id, reuse them if the cluster already exists, otherwise
+offer your own; then create (which either establishes the cluster or attaches to an
+identical one). On a mismatch, re-read the authoritative options and retry.
+
+```cpp
+// A stable rendezvous name that all cooperating hosts agree on (e.g. in a shared header).
+constexpr PCWSTR kClusterId = L"Contoso.Shell.Default";
+
+// Build the options this host would like if it turns out to be the first one in.
+wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> BuildMyOptions()
+{
+    auto options = Microsoft::WRL::Make<CoreWebView2ClusterEnvironmentOptions>();
+    CHECK_FAILURE(options->put_Id(kClusterId));
+    CHECK_FAILURE(options->put_Language(L"en-US"));
+    CHECK_FAILURE(options->put_AreBrowserExtensionsEnabled(FALSE));
+    return options;
+}
+
+void AppWindow::CreateSharedEnvironment()
+{
+    // Step 1 - synchronously ask what is already pinned for this id. No browser spawn.
+    wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> pinned;
+    HRESULT hr = GetCoreWebView2ClusterEnvironmentOptions(kClusterId, &pinned);
+
+    // Step 2 - reuse the pinned set if the cluster already exists, else offer my own.
+    wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> options =
+        (hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) ? BuildMyOptions() : pinned;
+
+    // Step 3 - same symmetric create either way: establishes, or attaches to an
+    // identical cluster.
+    CreateSharedEnvironmentWithOptions(options.get());
+}
+
+void AppWindow::CreateSharedEnvironmentWithOptions(
+    ICoreWebView2ClusterEnvironmentOptions* options)
+{
+    CHECK_FAILURE(CreateCoreWebView2ClusterEnvironment(
+        options,
+        Microsoft::WRL::Callback<ICoreWebView2CreateClusterEnvironmentCompletedHandler>(
+            [this](HRESULT result, ICoreWebView2Environment* environment) -> HRESULT
+            {
+                if (result == HRESULT_FROM_WIN32(ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH))
+                {
+                    // A live browser pinned a different set since my Get. Re-read the
+                    // authoritative options and retry once with them (or go private).
+                    wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> authoritative;
+                    if (SUCCEEDED(GetCoreWebView2ClusterEnvironmentOptions(
+                            kClusterId, &authoritative)) &&
+                        AcceptableForMe(authoritative.get()))
+                    {
+                        CreateSharedEnvironmentWithOptions(authoritative.get());
+                    }
+                    else
+                    {
+                        UsePrivateEnvironment();
+                    }
+                    return S_OK;
+                }
+                CHECK_FAILURE(result);
+
+                // Established the cluster, or attached to an identical one.
+                OnSharedEnvironmentReady(environment);
+                return S_OK;
+            })
+            .Get()));
+}
+```
+
+## .NET/WinRT
+
+```c#
+// A stable rendezvous name that all cooperating hosts agree on.
+const string ClusterId = "Contoso.Shell.Default";
+
+CoreWebView2ClusterEnvironmentOptions BuildMyOptions()
+{
+    return new CoreWebView2ClusterEnvironmentOptions()
+    {
+        Id = ClusterId,
+        Language = "en-US",
+        AreBrowserExtensionsEnabled = false,
+    };
+}
+
+async Task CreateSharedEnvironmentAsync()
+{
+    // Step 1 - synchronously read the pinned options for this id. No browser spawn.
+    // Returns null when nothing is pinned yet.
+    CoreWebView2ClusterEnvironmentOptions pinned =
+        CoreWebView2Environment.GetClusterEnvironmentOptions(ClusterId);
+
+    // Step 2 - reuse the pinned set, or offer my own if none exists yet.
+    CoreWebView2ClusterEnvironmentOptions options = pinned ?? BuildMyOptions();
+
+    try
+    {
+        // Step 3 - same symmetric create either way.
+        CoreWebView2Environment environment =
+            await CoreWebView2Environment.CreateClusterEnvironmentAsync(options);
+        OnSharedEnvironmentReady(environment);
+    }
+    catch (COMException ex) when
+        (ex.HResult == CoreWebView2ClusterEnvironmentOptions.OptionsMismatchHResult)
+    {
+        // A live browser pinned a different set since my Get. Re-read and retry, or
+        // fall back to a private environment.
+        CoreWebView2ClusterEnvironmentOptions authoritative =
+            CoreWebView2Environment.GetClusterEnvironmentOptions(ClusterId);
+        if (authoritative != null && AcceptableForMe(authoritative))
+        {
+            CoreWebView2Environment environment =
+                await CoreWebView2Environment.CreateClusterEnvironmentAsync(authoritative);
+            OnSharedEnvironmentReady(environment);
+        }
+        else
+        {
+            UsePrivateEnvironment();
+        }
+    }
+}
+```
+
+# API Details
+
+## Win32 C++
+
+```
+/// Establishes, or attaches to, a shared WebView2 cluster environment identified by
+/// the `Id` in `options`. This is the symmetric entry point every cooperating host
+/// calls with its full desired options.
+///
+/// The first host to establish a cluster for a given `Id` pins its options
+/// (first-creator-wins). A later host attaches when its options equal the pinned
+/// set (strict, full-set equality), and the completion handler receives the shared
+/// `ICoreWebView2Environment`. A host whose options differ from the pinned set does
+/// not attach: the completion handler is invoked with
+/// `ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH` and a null environment; that host
+/// should call `GetCoreWebView2ClusterEnvironmentOptions` to read the authoritative
+/// set and retry, or create a private (non-shared) environment instead.
+///
+/// The mapping from `Id` to the on-disk user data folder is a fixed function, so
+/// the same `Id` always resolves to the same layout.
+STDAPI CreateCoreWebView2ClusterEnvironment(
+    [in] ICoreWebView2ClusterEnvironmentOptions* options,
+    [in] ICoreWebView2CreateClusterEnvironmentCompletedHandler* handler);
+
+/// Synchronously reads the pinned options for the cluster identified by `id`,
+/// without spawning a browser. Use this to pre-flight before calling
+/// `CreateCoreWebView2ClusterEnvironment`: read what is already pinned and decide
+/// whether to reuse it or offer your own set.
+///
+/// Returns `S_OK` and the pinned options when a set is pinned for `id`. Returns
+/// `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)` and null `options` when nothing is pinned
+/// for `id` yet (the caller may create with its own options and become the pinner).
+///
+/// The value returned is a hint: it can be stale the instant it is read if another
+/// host pins a different set concurrently. `CreateCoreWebView2ClusterEnvironment`
+/// remains authoritative and validates against the live cluster.
+STDAPI GetCoreWebView2ClusterEnvironmentOptions(
+    [in] LPCWSTR id,
+    [out] ICoreWebView2ClusterEnvironmentOptions** options);
+
+/// The options used to establish or attach to a shared cluster environment. Only
+/// options that can be shared process-wide across cooperating hosts are present;
+/// process-incompatible options are intentionally omitted.
+[uuid(2F3A6D1E-6B9C-4E2A-9A1B-4C0F2D8E7A10), object, pointer_default(unique)]
+interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
+  /// The rendezvous name that identifies the cluster. All cooperating hosts agree
+  /// on this value out of band. Must not be null or empty.
+  [propget] HRESULT Id([out, retval] LPWSTR* id);
+  /// Sets the `Id` property.
+  [propput] HRESULT Id([in] LPCWSTR id);
+
+  /// Additional command-line switches passed to the shared browser process. Because
+  /// the process is shared, this value is part of the pinned set and is process-wide.
+  [propget] HRESULT AdditionalBrowserArguments([out, retval] LPWSTR* value);
+  /// Sets the `AdditionalBrowserArguments` property.
+  [propput] HRESULT AdditionalBrowserArguments([in] LPCWSTR value);
+
+  /// The default display language for the shared environment.
+  [propget] HRESULT Language([out, retval] LPWSTR* value);
+  /// Sets the `Language` property.
+  [propput] HRESULT Language([in] LPCWSTR value);
+
+  /// Whether single sign-on using the OS primary account is allowed.
+  [propget] HRESULT AllowSingleSignOnUsingOSPrimaryAccount([out, retval] BOOL* value);
+  /// Sets the `AllowSingleSignOnUsingOSPrimaryAccount` property.
+  [propput] HRESULT AllowSingleSignOnUsingOSPrimaryAccount([in] BOOL value);
+
+  /// Whether tracking prevention is enabled for the shared environment.
+  [propget] HRESULT EnableTrackingPrevention([out, retval] BOOL* value);
+  /// Sets the `EnableTrackingPrevention` property.
+  [propput] HRESULT EnableTrackingPrevention([in] BOOL value);
+
+  /// Whether browser extensions are enabled for the shared environment.
+  [propget] HRESULT AreBrowserExtensionsEnabled([out, retval] BOOL* value);
+  /// Sets the `AreBrowserExtensionsEnabled` property.
+  [propput] HRESULT AreBrowserExtensionsEnabled([in] BOOL value);
+
+  /// The channel search kind used to locate the WebView2 Runtime.
+  [propget] HRESULT ChannelSearchKind(
+      [out, retval] COREWEBVIEW2_CHANNEL_SEARCH_KIND* value);
+  /// Sets the `ChannelSearchKind` property.
+  [propput] HRESULT ChannelSearchKind([in] COREWEBVIEW2_CHANNEL_SEARCH_KIND value);
+
+  /// When TRUE (the default), the effective profile name is namespaced per host
+  /// executable (`"<HostExe>_<ProfileName>"`) to prevent *accidental* cross-app
+  /// profile use. This is anti-misuse, not a security boundary.
+  [propget] HRESULT PerExeProfileIsolation([out, retval] BOOL* value);
+  /// Sets the `PerExeProfileIsolation` property.
+  [propput] HRESULT PerExeProfileIsolation([in] BOOL value);
+
+  /// Gets the custom scheme registrations that are part of the pinned set. The
+  /// caller must free the returned array and release each element with
+  /// `CoTaskMemFree` / `Release`.
+  HRESULT GetCustomSchemeRegistrations(
+      [out] UINT32* count,
+      [out] ICoreWebView2CustomSchemeRegistration*** schemeRegistrations);
+  /// Sets the custom scheme registrations that are part of the pinned set.
+  HRESULT SetCustomSchemeRegistrations(
+      [in] UINT32 count,
+      [in] const ICoreWebView2CustomSchemeRegistration** schemeRegistrations);
+}
+
+/// Receives the result of `CreateCoreWebView2ClusterEnvironment`.
+[uuid(6C4B0A72-1D8E-4F3B-8C2A-5E9D7B1A0C34), object, pointer_default(unique)]
+interface ICoreWebView2CreateClusterEnvironmentCompletedHandler : IUnknown {
+  /// `errorCode` is:
+  ///  * `S_OK` - `environment` is the shared cluster environment (freshly
+  ///    established, or attached to an identical running cluster).
+  ///  * `ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH` - a cluster already exists for
+  ///    this `Id` with a different pinned set; `environment` is null. Call
+  ///    `GetCoreWebView2ClusterEnvironmentOptions` to read the authoritative set and
+  ///    retry, or create a private environment.
+  HRESULT Invoke(
+      [in] HRESULT errorCode,
+      [in] ICoreWebView2Environment* environment);
+}
+```
+
+`ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH` is returned as
+`HRESULT_FROM_WIN32(ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH)`.
+
+## .NET/WinRT
+
+The two global functions are surfaced as static methods on `CoreWebView2Environment`,
+mirroring how `CreateCoreWebView2EnvironmentWithOptions` maps to
+`CoreWebView2Environment.CreateAsync`. `GetClusterEnvironmentOptions` is synchronous
+and returns `null` when nothing is pinned (rather than throwing), matching the
+`ERROR_NOT_FOUND` case of the COM API.
+
+```c#
+namespace Microsoft.Web.WebView2.Core
+{
+    runtimeclass CoreWebView2ClusterEnvironmentOptions
+    {
+        CoreWebView2ClusterEnvironmentOptions();
+
+        String Id { get; set; };
+        String AdditionalBrowserArguments { get; set; };
+        String Language { get; set; };
+        Boolean AllowSingleSignOnUsingOSPrimaryAccount { get; set; };
+        Boolean EnableTrackingPrevention { get; set; };
+        Boolean AreBrowserExtensionsEnabled { get; set; };
+        CoreWebView2ChannelSearchKind ChannelSearchKind { get; set; };
+        Boolean PerExeProfileIsolation { get; set; };
+        IVector<CoreWebView2CustomSchemeRegistration> CustomSchemeRegistrations { get; };
+
+        // HRESULT of the options-mismatch failure, for callers that catch
+        // COMException from CreateClusterEnvironmentAsync.
+        static Int32 OptionsMismatchHResult { get; };
+    }
+
+    runtimeclass CoreWebView2Environment
+    {
+        // ...
+
+        // Establishes, or attaches to, the shared cluster identified by
+        // options.Id. Throws a COMException with HResult == OptionsMismatchHResult
+        // when a cluster already exists for that Id with a different pinned set.
+        static Windows.Foundation.IAsyncOperation<CoreWebView2Environment>
+            CreateClusterEnvironmentAsync(CoreWebView2ClusterEnvironmentOptions options);
+
+        // Synchronously reads the pinned options for the cluster id without
+        // spawning a browser. Returns null when nothing is pinned for id yet.
+        static CoreWebView2ClusterEnvironmentOptions GetClusterEnvironmentOptions(
+            String id);
+    }
+}
+```
+
+# Appendix
+
+## Storage, concurrency, and lifetime
+
+The pinned set lives in a per-`Id` record (for example a registry key such as
+`HKCU\Software\Microsoft\WebView2\SharedClusters\<Id>`) holding the serialized
+options plus the resolved UDF path. There is one named lock per cluster `Id`, and
+any host takes it while it establishes or attaches. The write happens inside the
+establish lock, only after the internal create succeeds:
+
+```text
+AcquireLock(Id)
+hr = <internal establish env for UDF(Id)>
+if SUCCEEDED(hr): WriteRecord(Id, options)   // still holding the lock
+ReleaseLock(Id)
+```
+
+Because both the create (which writes the pinned options) and `Get` (which reads
+them) coordinate through the same lock and record writes are atomic, a reader never
+sees a half-written set, and two creates racing when nothing exists yet cannot
+collide. Writing the caller's own options is authoritative because strict-equality
+means a success is either a fresh establish (this caller's options become the pinned
+set) or an attach whose options already equal the pinned set. The **live browser
+stays authoritative** on conflict, so a stale or missing record is self-healing: the
+next create attaches if options match, or returns
+`ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH` to re-read and retry. Lock acquisition
+must handle `WAIT_ABANDONED` so a crash while holding the lock does not wedge the
+next host.
+
+The per-`Id` record is kept as the forward-stable pinned set after the browser
+exits (it is a harmless, replayable recipe), which lets `Get` answer even when no
+browser is running. The pinned options a `Get` reads are configuration values, not
+liveness: the create path still decides liveness on the UDF, attaching if a shared
+browser is running and relaunching with the same options if the last host has
+exited. Nothing needs a background sweep.
+
+## Alternatives considered
+
+Two other API shapes were evaluated and rejected in favor of this one.
+
+**A. Create / Join role split.** One host `Create`s the cluster and pins options;
+everyone else `Join`s by name, passing no options, and `Join` hands back both the
+environment and the pinned options (so "learn the options" needs no separate read).
+Cleaner asymmetry, but it introduces a bootstrap race: if two hosts `Join` before
+anyone `Create`s, both get `NOT_FOUND` and need an extra rule (a designated creator,
+a `JoinOrCreate`, or bounded retry). The symmetric model in this spec avoids the
+"who creates first" race because every host runs the same create.
+
+**B. One synchronous getter, nothing else.** No cluster API at all: keep today's
+UDF-based sharing and only add
+`GetCoreWebView2EnvironmentOptions(userDataFolder, out options)` so a joiner can
+look before it leaps. Smallest possible surface and zero create-path change, but it
+does the least: attach still goes through today's create path and its existing
+errors, there is no named rendezvous, and there is no real "establish" step the
+runtime can guard with a lock. This spec's model was chosen because it makes shared
+behavior explicit and gives the runtime a lockable establish step; the getter-only
+shape remains a viable smaller-surface fallback if scope tightens.
+
+## Why these options are process-wide
+
+`ICoreWebView2ClusterEnvironmentOptions` deliberately excludes options that cannot
+hold a single value across a shared process tree. Some flags (for example the
+remote-debugging port or logging) are process-wide and can hold only one value, so
+in a cluster they are pinned by the first creator and are not per host. A model for
+per-app overrides inside a shared cluster is an open question (below).
+
+## Open questions
+
+- **Get semantics when not running.** Whether `Get` should return the pinned options
+  only while the cluster is running, or also when it is configured but not running.
+  This spec recommends the latter (forward-stable record) so `Get` can answer with
+  no browser spawned.
+- **Stronger profile-data security.** Real isolation (encryption with an app key, or
+  an OS-defined ACL) is out of scope; today `PerExeProfileIsolation` is anti-misuse
+  only and profile data in RAM is unencrypted.
+- **Renderer-process sharing across apps.** Under memory pressure the browser can
+  reduce site isolation and two hosts could share a renderer. Enterprise/vendor
+  renderers should be explicitly blocked from sharing.
+- **Per-app overrides in a shared cluster.** Process-wide flags can hold only one
+  value, so an override becomes per *cluster*, not per app; a per-app customization
+  model is unresolved.
+- **Coordinated option changes and shutdown.** Apps update on different timelines, so
+  a ready-to-restart or voting mechanism may be needed to apply an option change or
+  an upgrade consistently across a cluster. Today an option change lands on the next
+  app update or restart, and coordinating it is the apps' responsibility.
+- **Strict full-set equality is coarse.** An extensions-on vs extensions-off nuance
+  fails equality for both hosts; a finer compatibility model may be wanted later.

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -20,7 +20,7 @@ than by accident.
 
 This spec proposes the **symmetric `Create` + synchronous `Get`** model:
 
-- Every host calls the same symmetric `CreateCoreWebView2ClusterEnvironment` with
+- Every host calls the same symmetric `CreateOrJoinCoreWebView2ClusterEnvironment` with
   its full desired options. The **first** host to establish a cluster with a given
   `Id` pins its options (first-creator-wins). A later host that passes an identical
   set attaches to the running cluster; a host that passes a different set gets a
@@ -65,7 +65,7 @@ The recommended usage pattern is **"Get, then Create"**:
    anything, is already pinned. This does not launch a browser.
 2. If something is pinned, reuse it (attach). If nothing is pinned yet, offer your
    own options (you become the pinner).
-3. Call `CreateCoreWebView2ClusterEnvironment` with the chosen options. You either
+3. Call `CreateOrJoinCoreWebView2ClusterEnvironment` with the chosen options. You either
    establish the cluster or attach to an identical one.
 
 `Get` is only a hint: it can race with another host that pins a different set the
@@ -133,9 +133,9 @@ void AppWindow::CreateSharedEnvironment()
 void AppWindow::CreateSharedEnvironmentWithOptions(
     ICoreWebView2ClusterEnvironmentOptions* options)
 {
-    CHECK_FAILURE(CreateCoreWebView2ClusterEnvironment(
+    CHECK_FAILURE(CreateOrJoinCoreWebView2ClusterEnvironment(
         options,
-        Microsoft::WRL::Callback<ICoreWebView2CreateClusterEnvironmentCompletedHandler>(
+        Microsoft::WRL::Callback<ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler>(
             [this](HRESULT result, ICoreWebView2Environment* environment) -> HRESULT
             {
                 if (result == HRESULT_FROM_WIN32(ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH))
@@ -195,7 +195,7 @@ async Task CreateSharedEnvironmentAsync()
     {
         // Step 3 - same symmetric create either way.
         CoreWebView2Environment environment =
-            await CoreWebView2Environment.CreateClusterEnvironmentAsync(options);
+            await CoreWebView2Environment.CreateOrJoinClusterEnvironmentAsync(options);
         OnSharedEnvironmentReady(environment);
     }
     catch (COMException ex) when
@@ -208,7 +208,7 @@ async Task CreateSharedEnvironmentAsync()
         if (authoritative != null && AcceptableForMe(authoritative))
         {
             CoreWebView2Environment environment =
-                await CoreWebView2Environment.CreateClusterEnvironmentAsync(authoritative);
+                await CoreWebView2Environment.CreateOrJoinClusterEnvironmentAsync(authoritative);
             OnSharedEnvironmentReady(environment);
         }
         else
@@ -239,13 +239,13 @@ async Task CreateSharedEnvironmentAsync()
 ///
 /// The mapping from `Id` to the on-disk user data folder is a fixed function, so
 /// the same `Id` always resolves to the same layout.
-STDAPI CreateCoreWebView2ClusterEnvironment(
+STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
     [in] ICoreWebView2ClusterEnvironmentOptions* options,
-    [in] ICoreWebView2CreateClusterEnvironmentCompletedHandler* handler);
+    [in] ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler* handler);
 
 /// Synchronously reads the pinned options for the cluster identified by `id`,
 /// without spawning a browser. Use this to pre-flight before calling
-/// `CreateCoreWebView2ClusterEnvironment`: read what is already pinned and decide
+/// `CreateOrJoinCoreWebView2ClusterEnvironment`: read what is already pinned and decide
 /// whether to reuse it or offer your own set.
 ///
 /// Returns `S_OK` and the pinned options when a set is pinned for `id`. Returns
@@ -253,7 +253,7 @@ STDAPI CreateCoreWebView2ClusterEnvironment(
 /// for `id` yet (the caller may create with its own options and become the pinner).
 ///
 /// The value returned is a hint: it can be stale the instant it is read if another
-/// host pins a different set concurrently. `CreateCoreWebView2ClusterEnvironment`
+/// host pins a different set concurrently. `CreateOrJoinCoreWebView2ClusterEnvironment`
 /// remains authoritative and validates against the live cluster.
 ///
 /// State: the pinned options are persisted per cluster `Id` in the user data folder
@@ -333,9 +333,9 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
       [in] const ICoreWebView2CustomSchemeRegistration** schemeRegistrations);
 }
 
-/// Receives the result of `CreateCoreWebView2ClusterEnvironment`.
+/// Receives the result of `CreateOrJoinCoreWebView2ClusterEnvironment`.
 [uuid(6C4B0A72-1D8E-4F3B-8C2A-5E9D7B1A0C34), object, pointer_default(unique)]
-interface ICoreWebView2CreateClusterEnvironmentCompletedHandler : IUnknown {
+interface ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler : IUnknown {
   /// `errorCode` is:
   ///  * `S_OK` - `environment` is the shared cluster environment (freshly
   ///    established, or attached to an identical running cluster).
@@ -381,7 +381,7 @@ namespace Microsoft.Web.WebView2.Core
         IVector<CoreWebView2CustomSchemeRegistration> CustomSchemeRegistrations { get; };
 
         // HRESULT of the options-mismatch failure, for callers that catch
-        // COMException from CreateClusterEnvironmentAsync.
+        // COMException from CreateOrJoinClusterEnvironmentAsync.
         static Int32 OptionsMismatchHResult { get; };
     }
 
@@ -393,7 +393,7 @@ namespace Microsoft.Web.WebView2.Core
         // options.Id. Throws a COMException with HResult == OptionsMismatchHResult
         // when a cluster already exists for that Id with a different pinned set.
         static Windows.Foundation.IAsyncOperation<CoreWebView2Environment>
-            CreateClusterEnvironmentAsync(CoreWebView2ClusterEnvironmentOptions options);
+            CreateOrJoinClusterEnvironmentAsync(CoreWebView2ClusterEnvironmentOptions options);
 
         // Synchronously reads the pinned options for the cluster id without
         // spawning a browser. Returns null when nothing is pinned for id yet.

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -72,9 +72,9 @@ race, at which point you re-`Get` the now-authoritative options and retry, or fa
 back to a private (non-shared) environment.
 
 Profile isolation in a cluster is **anti-misuse, not a security boundary**. The
-`PerExeProfileIsolation` option prevents *accidental* cross-app profile use; it does
-not encrypt or ACL profile data. Any app that knows the cluster `Id` and profile
-name can use a shared profile.
+`PerHostProfileIsolation` option prevents *accidental* cross-app profile use; it
+does not encrypt or ACL profile data. Any app that knows the cluster `Id` and
+profile name can use a shared profile.
 
 # Examples
 
@@ -239,6 +239,11 @@ STDAPI CreateCoreWebView2ClusterEnvironment(
 /// The value returned is a hint: it can be stale the instant it is read if another
 /// host pins a different set concurrently. `CreateCoreWebView2ClusterEnvironment`
 /// remains authoritative and validates against the live cluster.
+///
+/// State: the pinned options are persisted per cluster `Id` in the user data folder
+/// resolved from that `Id` (a per-`Id` record). The record survives after the
+/// cluster's browser process exits, so `Get` answers whether or not the cluster is
+/// currently running. See the Appendix for storage and lifetime details.
 STDAPI GetCoreWebView2ClusterEnvironmentOptions(
     [in] LPCWSTR id,
     [out] ICoreWebView2ClusterEnvironmentOptions** options);
@@ -287,11 +292,13 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   [propput] HRESULT ChannelSearchKind([in] COREWEBVIEW2_CHANNEL_SEARCH_KIND value);
 
   /// When TRUE (the default), the effective profile name is namespaced per host
-  /// executable (`"<HostExe>_<ProfileName>"`) to prevent *accidental* cross-app
-  /// profile use. This is anti-misuse, not a security boundary.
-  [propget] HRESULT PerExeProfileIsolation([out, retval] BOOL* value);
-  /// Sets the `PerExeProfileIsolation` property.
-  [propput] HRESULT PerExeProfileIsolation([in] BOOL value);
+  /// application (`"<HostName>_<ProfileName>"`) to prevent *accidental* cross-app
+  /// profile use. This is anti-misuse, not a security boundary. The name is
+  /// deliberately OS-neutral: `<HostName>` is the host application identity on the
+  /// current platform (the executable name on Windows).
+  [propget] HRESULT PerHostProfileIsolation([out, retval] BOOL* value);
+  /// Sets the `PerHostProfileIsolation` property.
+  [propput] HRESULT PerHostProfileIsolation([in] BOOL value);
 
   /// Gets the custom scheme registrations that are part of the pinned set. The
   /// caller must free the returned array and release each element with
@@ -346,7 +353,7 @@ namespace Microsoft.Web.WebView2.Core
         Boolean EnableTrackingPrevention { get; set; };
         Boolean AreBrowserExtensionsEnabled { get; set; };
         CoreWebView2ChannelSearchKind ChannelSearchKind { get; set; };
-        Boolean PerExeProfileIsolation { get; set; };
+        Boolean PerHostProfileIsolation { get; set; };
         IVector<CoreWebView2CustomSchemeRegistration> CustomSchemeRegistrations { get; };
 
         // HRESULT of the options-mismatch failure, for callers that catch
@@ -438,6 +445,38 @@ remote-debugging port or logging) are process-wide and can hold only one value, 
 in a cluster they are pinned by the first creator and are not per host. A model for
 per-app overrides inside a shared cluster is an open question (below).
 
+## API-shape decisions for reviewers
+
+**New options type vs. extending `ICoreWebView2EnvironmentOptions`.** This spec adds
+a *new* `ICoreWebView2ClusterEnvironmentOptions` rather than reusing or extending the
+existing `ICoreWebView2EnvironmentOptions`. The tradeoff:
+
+- *New type (chosen).* Lets the surface expose *only* the options that are valid to
+  share process-wide, plus the cluster `Id`. Options that cannot hold a single value
+  across a shared process (see above) simply do not exist on the type, so a host
+  cannot set something that would silently be ignored. Cost: a parallel type that
+  duplicates several members already present on `ICoreWebView2EnvironmentOptions`,
+  and a small ongoing burden to keep the shared subset in sync as the existing
+  options type grows.
+- *Extend the existing type.* Would avoid duplication and let hosts reuse option-
+  building code (the getter-only alternative B does exactly this). Cost: the existing
+  type carries members that are meaningless or unsafe when shared, so the API would
+  have to document per-member "ignored in a cluster" behavior instead of omitting it.
+
+Reviewers should confirm the "omit what can't be shared" goal is worth the duplication
+before this is locked in; if not, the fallback is to accept an
+`ICoreWebView2EnvironmentOptions` plus a separate `Id` parameter.
+
+**How the mismatch surfaces in .NET/WinRT.** This spec projects the mismatch as a
+`COMException` whose `HResult` equals a static `OptionsMismatchHResult`, which is
+functional but not idiomatic for WinRT (callers must compare an HRESULT in a `catch`
+filter). An alternative worth considering is returning a result object or status
+enum from `CreateClusterEnvironmentAsync` (for example a
+`CoreWebView2ClusterEnvironmentCreateResult` with `Environment` and a `Status` of
+`Succeeded` / `OptionsMismatch`), so the mismatch is a normal return value rather
+than an exception. The COM handler already models this as a non-fault HRESULT, so
+either projection is possible.
+
 ## Open questions
 
 - **Get semantics when not running.** Whether `Get` should return the pinned options
@@ -445,7 +484,7 @@ per-app overrides inside a shared cluster is an open question (below).
   This spec recommends the latter (forward-stable record) so `Get` can answer with
   no browser spawned.
 - **Stronger profile-data security.** Real isolation (encryption with an app key, or
-  an OS-defined ACL) is out of scope; today `PerExeProfileIsolation` is anti-misuse
+  an OS-defined ACL) is out of scope; today `PerHostProfileIsolation` is anti-misuse
   only and profile data in RAM is unencrypted.
 - **Renderer-process sharing across apps.** Under memory pressure the browser can
   reduce site isolation and two hosts could share a renderer. Enterprise/vendor

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -217,7 +217,7 @@ async Task CreateSharedEnvironmentAsync()
 {
     try
     {
-        // Step 1 - synchronously read the cluster's options for this id. No browser
+        // Step 1 - read the cluster's options for this `Id`. No browser
         // spawn. Returns null when no cluster exists yet.
         CoreWebView2ClusterEnvironmentOptions existing =
             CoreWebView2Environment.GetClusterEnvironmentOptions(ClusterId);
@@ -269,7 +269,7 @@ async Task CreateSharedEnvironmentAsync()
 
 ## Win32 C++
 
-```
+```cpp
 /// The outcome of `CreateOrJoinCoreWebView2ClusterEnvironment`, reported to the
 /// completion handler when its `errorCode` is `S_OK`.
 [v1_enum] typedef enum COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS {
@@ -287,28 +287,28 @@ async Task CreateSharedEnvironmentAsync()
 /// by the `Id` in `options`. If no cluster exists for the `Id`, this establishes
 /// one and the caller's options become the cluster's options. If a cluster already
 /// exists and the caller's options match it, the caller attaches to it. The outcome
-/// is reported to the completion handler as a `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS`.
+/// is reported to `handler` as a `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS`.
 ///
-/// The synchronous return value reports whether the asynchronous operation could be
-/// started:
-///   S_OK                                    -> operation started; the completion
-///                                              handler will be invoked with the result.
-///   E_INVALIDARG                            -> `options` or its `Id` is invalid.
+/// The return value reports whether `CreateOrJoinCoreWebView2ClusterEnvironment`
+/// could start:
+///   S_OK                                    -> started; `handler` will be invoked
+///                                              with the result.
+///   E_INVALIDARG                            -> `options` or its `Id` is invalid;
+///                                              `handler` is not invoked.
 ///   HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) -> the host cannot share or access the
 ///                                              cluster's user data folder (for
 ///                                              example a sandboxed or low-integrity
-///                                              process such as a UWP app); the
-///                                              completion handler is not invoked.
-/// When the return value is a failing `HRESULT`, the completion handler is not
-/// invoked.
+///                                              process such as a UWP app); `handler`
+///                                              is not invoked.
+/// When the return value is any failing `HRESULT`, `handler` is not invoked.
 STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
     [in] ICoreWebView2ClusterEnvironmentOptions* options,
     [in] ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler* handler);
 
-/// Synchronously reads the options of the cluster identified by `id` without
-/// creating or attaching to a cluster. Returns `S_OK` and the cluster's options
-/// when a cluster exists for `id`, or `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)`
-/// and `nullptr` `options` when no cluster exists for `id`. The options are available
+/// Reads the options of the cluster identified by its `Id` without creating or
+/// attaching to a cluster. Returns `S_OK` and the cluster's options when a cluster
+/// exists for that `Id`, or `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)` and `nullptr`
+/// `options` when no cluster exists for that `Id`. The options are available
 /// whether or not the cluster is currently running.
 ///
 /// Returns `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)` and `nullptr` `options` in hosts
@@ -458,8 +458,8 @@ namespace Microsoft.Web.WebView2.Core
         static Windows.Foundation.IAsyncOperation<CoreWebView2ClusterEnvironmentCreateResult>
             CreateOrJoinClusterEnvironmentAsync(CoreWebView2ClusterEnvironmentOptions options);
 
-        // Synchronously reads the options of the cluster identified by id. Returns
-        // null when no cluster exists for id. Throws a COMException whose
+        // Reads the options of the cluster identified by its Id. Returns
+        // null when no cluster exists for that Id. Throws a COMException whose
         // HResult is HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) when the host cannot
         // share or access the cluster's user data folder.
         static CoreWebView2ClusterEnvironmentOptions GetClusterEnvironmentOptions(

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -44,12 +44,12 @@ host applications deliberately share, identified by a well-known `ClusterName` s
 those hosts agree on out of band. All hosts that establish a cluster with the same
 `ClusterName` run inside one shared browser process and one on-disk user data folder.
 
-A host process must be able to create and share the cluster's per-user user data
-folder. A host that cannot, such as a sandboxed AppContainer process (for example, a
-UWP app), fails with `ERROR_NOT_SUPPORTED`. A transient failure to access an
-otherwise-supported cluster's user data folder (for example, an access-denied or
-sharing violation) is not reported as `ERROR_NOT_SUPPORTED`; it surfaces as an ordinary
-create failure.
+Cluster environments are supported for standard desktop host processes: non-sandboxed,
+non-containerized applications running at medium or high integrity level. Applications
+that cannot create or share the cluster's per-user user data folder fail with
+`ERROR_NOT_SUPPORTED`. A transient failure to access an otherwise-supported cluster's
+user data folder (for example, an access-denied or sharing violation) is not reported
+as `ERROR_NOT_SUPPORTED`; it surfaces as an ordinary create failure.
 
 These entry points exist only in WebView2 Runtime versions that implement them. On an
 older runtime they are unavailable, so a host should feature-detect the API using the
@@ -350,6 +350,54 @@ async Task CreateSharedEnvironmentAsync()
     {
         UsePrivateEnvironment();
     }
+}
+```
+
+## Deleting a cluster's user data folder
+
+WebView2 does not delete a cluster's user data folder automatically, even after the
+cluster's browser process exits. Cleaning it up is the cooperating applications' shared
+responsibility. Because several applications can use the same cluster, no single
+application should delete the folder while another might still use it. When the last
+cooperating application is being uninstalled, that application should delete the folder
+so it is not left behind on disk.
+
+Before deleting, the application must confirm that no other cooperating application is
+still using the cluster and that the cluster is not running (a cluster exists only
+while its browser process is running, and the folder cannot be deleted while it is in
+use). How an application tracks the remaining cooperating applications, for example a
+shared install registration or reference count, is app-specific and outside the scope
+of this API.
+
+```cpp
+// Called during uninstall of a cooperating application.
+void AppWindow::DeleteClusterUserDataFolderOnUninstall()
+{
+    // 1. App-specific check: proceed only if this is the last cooperating
+    //    application, so no other application is still using this cluster.
+    if (OtherClusterAppsStillInstalled(kClusterName))
+        return;
+
+    // 2. Read the cluster's user data folder path from the environment this
+    //    application joined.
+    wil::unique_cotaskmem_string userDataFolder;
+    CHECK_FAILURE(m_clusterEnvironment->get_UserDataFolder(&userDataFolder));
+
+    // 3. The folder cannot be deleted while the shared browser process is running, so
+    //    delete it once BrowserProcessExited reports that the process has fully exited,
+    //    then release all references to let it exit. This is the same pattern used to
+    //    delete an ordinary user data folder.
+    std::wstring folder = userDataFolder.get();
+    CHECK_FAILURE(m_clusterEnvironment->add_BrowserProcessExited(
+        Microsoft::WRL::Callback<ICoreWebView2BrowserProcessExitedEventHandler>(
+            [folder](ICoreWebView2Environment*,
+                     ICoreWebView2BrowserProcessExitedEventArgs*) -> HRESULT
+            {
+                DeleteDirectoryRecursive(folder.c_str());
+                return S_OK;
+            }).Get(),
+        nullptr));
+    m_clusterEnvironment.reset();
 }
 ```
 

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -3,30 +3,32 @@ Shared WebView2 Cluster Environment
 
 # Background
 
-Today an application gets a WebView2 by calling
+Today an application creates a WebView2 by calling
 [`CreateCoreWebView2EnvironmentWithOptions`](https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions)
 and passing a `UserDataFolder` (UDF). Two hosts that pass the *same* UDF already
-share a single browser process tree. But that sharing is implicit: it is keyed
-entirely on the UDF path, the first launcher silently pins the environment options
-for everyone else, and a second host has no way to learn what those pinned options
-are before it attaches. If the second host's options disagree with the pinned set,
+share a single browser process. But that sharing is implicit: it is keyed
+entirely on the UDF path, the first launcher silently fixes the environment options
+for everyone else, and a second host has no way to learn what those options
+are before it attaches. If the second host's options disagree with the existing set,
 it only finds out after it has already paid to launch, and the failure surfaces as a
 generic create error.
 
 We want a first-class, *explicit* way for a set of cooperating host apps to opt into
 one shared WebView2 environment — a "cluster" — and to agree on the shared options up
-front.
+front. By cooperating host apps we mean applications that trust one another and agree
+on a shared cluster `Id` out of band; sharing is by convention, and the runtime does
+not restrict which apps may join a cluster.
 
 This spec proposes the **symmetric create-or-join + synchronous `Get`** model:
 
 - Every host calls the same symmetric `CreateOrJoinCoreWebView2ClusterEnvironment` with
   its full desired options. The **first** host to establish a cluster with a given
-  `Id` pins its options (first-creator-wins). A later host that passes an identical
-  set attaches to the running cluster; a host that passes a different set gets a
-  typed `ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH`.
+  `Id` fixes the cluster's options (first-creator-wins). A later host that passes matching
+  options attaches to the running cluster; a host that passes different options gets a
+  completion status of `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`.
 - A separate **synchronous** `GetCoreWebView2ClusterEnvironmentOptions` reads the
-  pinned set back for an `Id` without spawning a browser, so a host can pre-flight:
-  read what is already pinned, decide whether it likes it, then create.
+  cluster's options back for an `Id` without spawning a browser, so a host can
+  pre-flight: read what the cluster already uses, decide whether it likes it, then create.
 
 Sharing intent is expressed by an `Id` (a stable rendezvous name that all
 cooperating hosts agree on). The mapping from `Id` to on-disk UDF path is a fixed
@@ -38,14 +40,16 @@ applies to the on-disk layout, not just to the live process.
 A **cluster environment** is a WebView2 environment that a group of cooperating
 host applications deliberately share, identified by a well-known `Id` string that
 those hosts agree on out of band. All hosts that establish a cluster with the same
-`Id` run inside one browser process tree and one on-disk user data folder.
+`Id` run inside one shared browser process and one on-disk user data folder.
 
 Unlike `CreateCoreWebView2EnvironmentWithOptions`, you do **not** pass a user data
 folder. The runtime derives the folder from the cluster `Id` through a fixed
 mapping, so every host that uses the same `Id` resolves to the same on-disk layout.
+A cluster occupies its own user data folder namespace: it never joins or collides
+with an environment created by `CreateCoreWebView2EnvironmentWithOptions`.
 
-The **pinned options** are the `ICoreWebView2ClusterEnvironmentOptions` that the
-first host to establish the cluster supplied. Because a browser process tree is a
+The **cluster options** are the `ICoreWebView2ClusterEnvironmentOptions` that the
+first host to establish the cluster supplied. Because a shared browser process is a
 single process-wide configuration, those options cannot differ per host, so the
 first establishing caller's set becomes authoritative for the lifetime of the
 cluster. Options that cannot be shared process-wide are intentionally absent from
@@ -53,35 +57,38 @@ cluster. Options that cannot be shared process-wide are intentionally absent fro
 
 The recommended usage pattern is **"Get, then Create"**:
 
-1. Synchronously `GetCoreWebView2ClusterEnvironmentOptions(id)` to see what, if
-   anything, is already pinned. This does not launch a browser.
-2. If something is pinned, reuse it (attach). If nothing is pinned yet, offer your
-   own options (you become the pinner).
+1. Synchronously `GetCoreWebView2ClusterEnvironmentOptions(id)` to see what options,
+   if any, the cluster already uses. This does not launch a browser.
+2. If a cluster exists, reuse its options (attach). If none exists yet, offer your
+   own options (yours become the cluster's).
 3. Call `CreateOrJoinCoreWebView2ClusterEnvironment` with the chosen options. You either
    establish the cluster or attach to one with matching options.
 
-`Get` is only a hint: it can race with another host that pins a different set the
-instant after you read. The live browser stays authoritative, so `Create` still
-validates and returns `ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH` if you lost the
-race, at which point you re-`Get` the now-authoritative options and retry, or fall
-back to a private (non-shared) environment.
+`Get` is only a hint: it can race with another host that establishes a cluster with
+different options the instant after you read. The live browser stays authoritative,
+so `Create` still validates and reports a status of
+`COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH` if you lost the race, at
+which point you re-`Get` the now-authoritative options and retry, or fall back to a
+private (non-shared) environment.
 
-Profile isolation in a cluster is **anti-misuse, not a security boundary**. The
-`PerHostProfileIsolation` option prevents *accidental* cross-app profile use; it
-does not encrypt or ACL profile data. Any app that knows the cluster `Id` and
-profile name can use a shared profile.
+Profile isolation in a cluster is **anti-misuse, not a security boundary**. When
+`PerHostProfileIsolation` is TRUE (the default), profile names are namespaced per
+host application, so two different apps that happen to use the same profile name do
+not accidentally end up sharing one profile. This is not a security boundary: it
+does not encrypt or ACL profile data, and apps that deliberately use the same host
+identity and profile name can still share a profile.
 
 # Examples
 
 ## Win32 C++
 
-The example shows the recommended "Get, then Create" flow: read the pinned options
+The example shows the recommended "Get, then Create" flow: read the cluster's options
 for a well-known cluster id, reuse them if the cluster already exists, otherwise
 offer your own; then create (which either establishes the cluster or attaches to one
 with matching options). On a mismatch, re-read the authoritative options and retry.
 
 ```cpp
-// A stable rendezvous name that all cooperating hosts agree on (e.g. in a shared header).
+// A stable rendezvous name that all cooperating hosts agree on.
 constexpr PCWSTR kClusterId = L"Contoso.Shell.Default";
 
 // Build the options this host would like if it turns out to be the first one in.
@@ -96,20 +103,27 @@ wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> BuildMyOptions()
 
 void AppWindow::CreateSharedEnvironment()
 {
-    // Step 1 - synchronously ask what is already pinned for this id. No browser spawn.
-    wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> pinned;
-    HRESULT hr = GetCoreWebView2ClusterEnvironmentOptions(kClusterId, &pinned);
+    // Step 1 - synchronously ask what options the cluster already uses. No browser spawn.
+    wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> existing;
+    HRESULT hr = GetCoreWebView2ClusterEnvironmentOptions(kClusterId, &existing);
 
-    // Step 2 - reuse the pinned set if the cluster already exists; offer my own if
-    // nothing is pinned yet. Any other failure is a real error.
+    // Step 2 - reuse the cluster's options if it already exists; offer my own if none
+    // exists yet. If cluster environments are not supported in this host, go private.
     wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> options;
     if (SUCCEEDED(hr))
     {
-        options = pinned;
+        options = existing;
     }
     else if (hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND))
     {
         options = BuildMyOptions();
+    }
+    else if (hr == HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED))
+    {
+        // Sandboxed or low-integrity process (for example a UWP app) that cannot
+        // share or access the cluster's user data folder.
+        UsePrivateEnvironment();
+        return;
     }
     else
     {
@@ -125,15 +139,27 @@ void AppWindow::CreateSharedEnvironment()
 void AppWindow::CreateSharedEnvironmentWithOptions(
     ICoreWebView2ClusterEnvironmentOptions* options)
 {
-    CHECK_FAILURE(CreateOrJoinCoreWebView2ClusterEnvironment(
+    HRESULT hr = CreateOrJoinCoreWebView2ClusterEnvironment(
         options,
         Microsoft::WRL::Callback<ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler>(
-            [this](HRESULT result, ICoreWebView2Environment* environment) -> HRESULT
+            [this](HRESULT errorCode, COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS status,
+                   ICoreWebView2Environment* environment) -> HRESULT
             {
-                if (result == HRESULT_FROM_WIN32(ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH))
+                // A failing errorCode is an unexpected failure (for example the
+                // runtime could not be found). Handle it as usual.
+                CHECK_FAILURE(errorCode);
+
+                switch (status)
                 {
-                    // A live browser pinned a different set since my Get. Re-read the
-                    // authoritative options and retry once with them (or go private).
+                case COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED:
+                    // Established the cluster, or attached to one with matching options.
+                    OnSharedEnvironmentReady(environment);
+                    break;
+
+                case COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH:
+                {
+                    // A live cluster has different options than mine. Re-read the
+                    // authoritative options and retry with them (or go private).
                     wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> authoritative;
                     if (SUCCEEDED(GetCoreWebView2ClusterEnvironmentOptions(
                             kClusterId, &authoritative)) &&
@@ -145,15 +171,22 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
                     {
                         UsePrivateEnvironment();
                     }
-                    return S_OK;
+                    break;
                 }
-                CHECK_FAILURE(result);
-
-                // Established the cluster, or attached to one with matching options.
-                OnSharedEnvironmentReady(environment);
+                }
                 return S_OK;
             })
-            .Get()));
+            .Get());
+
+    if (hr == HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED))
+    {
+        // This host cannot share or access the cluster's user data folder (for
+        // example a sandboxed or low-integrity process such as a UWP app). Cluster
+        // environments are unavailable here; use a private environment instead.
+        UsePrivateEnvironment();
+        return;
+    }
+    CHECK_FAILURE(hr);
 }
 ```
 
@@ -162,10 +195,6 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
 ```c#
 // A stable rendezvous name that all cooperating hosts agree on.
 const string ClusterId = "Contoso.Shell.Default";
-
-// HRESULT_FROM_WIN32(ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH). Matches the value
-// thrown as a COMException.HResult when the pinned set differs from ours.
-const int OptionsMismatchHResult = unchecked((int)0x8007139F);
 
 CoreWebView2ClusterEnvironmentOptions BuildMyOptions()
 {
@@ -179,37 +208,52 @@ CoreWebView2ClusterEnvironmentOptions BuildMyOptions()
 
 async Task CreateSharedEnvironmentAsync()
 {
-    // Step 1 - synchronously read the pinned options for this id. No browser spawn.
-    // Returns null when nothing is pinned yet.
-    CoreWebView2ClusterEnvironmentOptions pinned =
-        CoreWebView2Environment.GetClusterEnvironmentOptions(ClusterId);
-
-    // Step 2 - reuse the pinned set, or offer my own if none exists yet.
-    CoreWebView2ClusterEnvironmentOptions options = pinned ?? BuildMyOptions();
-
     try
     {
-        // Step 3 - same symmetric create either way.
-        CoreWebView2Environment environment =
-            await CoreWebView2Environment.CreateOrJoinClusterEnvironmentAsync(options);
-        OnSharedEnvironmentReady(environment);
-    }
-    catch (COMException ex) when (ex.HResult == OptionsMismatchHResult)
-    {
-        // A live browser pinned a different set since my Get. Re-read and retry, or
-        // fall back to a private environment.
-        CoreWebView2ClusterEnvironmentOptions authoritative =
+        // Step 1 - synchronously read the cluster's options for this id. No browser
+        // spawn. Returns null when no cluster exists yet.
+        CoreWebView2ClusterEnvironmentOptions existing =
             CoreWebView2Environment.GetClusterEnvironmentOptions(ClusterId);
-        if (authoritative != null && AcceptableForMe(authoritative))
+
+        // Step 2 - reuse the cluster's options, or offer my own if none exists yet.
+        CoreWebView2ClusterEnvironmentOptions options = existing ?? BuildMyOptions();
+
+        // Step 3 - same symmetric create either way. A failing create (for example
+        // the runtime could not be found, or cluster environments are not supported
+        // in this host) throws; the expected outcomes come back as Status.
+        CoreWebView2ClusterEnvironmentCreateResult result =
+            await CoreWebView2Environment.CreateOrJoinClusterEnvironmentAsync(options);
+
+        if (result.Status == CoreWebView2ClusterEnvironmentStatus.OptionsMismatch)
         {
-            CoreWebView2Environment environment =
-                await CoreWebView2Environment.CreateOrJoinClusterEnvironmentAsync(authoritative);
-            OnSharedEnvironmentReady(environment);
+            // A live cluster has different options than ours. Re-read the
+            // authoritative options and retry once with them.
+            CoreWebView2ClusterEnvironmentOptions authoritative =
+                CoreWebView2Environment.GetClusterEnvironmentOptions(ClusterId);
+            if (authoritative != null && AcceptableForMe(authoritative))
+            {
+                result =
+                    await CoreWebView2Environment.CreateOrJoinClusterEnvironmentAsync(authoritative);
+            }
+        }
+
+        if (result.Status == CoreWebView2ClusterEnvironmentStatus.Succeeded)
+        {
+            // Established the cluster, or attached to one with matching options.
+            OnSharedEnvironmentReady(result.Environment);
         }
         else
         {
+            // Still mismatched after retrying; fall back to a private environment.
             UsePrivateEnvironment();
         }
+    }
+    // HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED). This host cannot share or access the
+    // cluster's user data folder (for example a sandboxed or low-integrity process
+    // such as a UWP app); use a private environment instead.
+    catch (COMException ex) when (ex.HResult == unchecked((int)0x80070032))
+    {
+        UsePrivateEnvironment();
     }
 }
 ```
@@ -219,13 +263,37 @@ async Task CreateSharedEnvironmentAsync()
 ## Win32 C++
 
 ```
+/// The outcome of `CreateOrJoinCoreWebView2ClusterEnvironment`, reported to the
+/// completion handler when its `errorCode` is `S_OK`.
+[v1_enum] typedef enum COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS {
+  /// The shared cluster environment is ready, either freshly established or attached
+  /// to an existing cluster with matching options.
+  COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED,
+  /// A cluster already exists for this `Id` with different options. No environment is
+  /// provided; read the cluster's options with
+  /// `GetCoreWebView2ClusterEnvironmentOptions` and retry, or use a private
+  /// (non-shared) environment.
+  COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH,
+} COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS;
+
 /// Establishes, or attaches to, the shared WebView2 cluster environment identified
 /// by the `Id` in `options`. If no cluster exists for the `Id`, this establishes
 /// one and the caller's options become the cluster's options. If a cluster already
-/// exists and the caller's options match it, the completion handler receives the
-/// shared `ICoreWebView2Environment`. If they do not match, the completion handler
-/// is invoked with `ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH` and a null
-/// environment.
+/// exists and the caller's options match it, the caller attaches to it. The outcome
+/// is reported to the completion handler as a `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS`.
+///
+/// The synchronous return value reports whether the asynchronous operation could be
+/// started:
+///   S_OK                                    -> operation started; the completion
+///                                              handler will be invoked with the result.
+///   E_INVALIDARG                            -> `options` or its `Id` is invalid.
+///   HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) -> the host cannot share or access the
+///                                              cluster's user data folder (for
+///                                              example a sandboxed or low-integrity
+///                                              process such as a UWP app); the
+///                                              completion handler is not invoked.
+/// When the return value is a failing `HRESULT`, the completion handler is not
+/// invoked.
 STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
     [in] ICoreWebView2ClusterEnvironmentOptions* options,
     [in] ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler* handler);
@@ -235,6 +303,10 @@ STDAPI CreateOrJoinCoreWebView2ClusterEnvironment(
 /// when a cluster is configured for `id`, or `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)`
 /// and null `options` when none is. The options are available whether or not the
 /// cluster is currently running.
+///
+/// Returns `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)` and null `options` in hosts
+/// that cannot share or access the cluster's user data folder, for example a
+/// sandboxed or low-integrity process such as a UWP app.
 STDAPI GetCoreWebView2ClusterEnvironmentOptions(
     [in] LPCWSTR id,
     [out] ICoreWebView2ClusterEnvironmentOptions** options);
@@ -242,8 +314,10 @@ STDAPI GetCoreWebView2ClusterEnvironmentOptions(
 /// The options used to establish or attach to a shared cluster environment.
 interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   /// The name that identifies the cluster. All cooperating hosts use the same
-  /// value. Must not be null or empty. The `Id` is case-insensitive and must be a
-  /// valid file-system folder name; otherwise the call fails with `E_INVALIDARG`.
+  /// value. Use a stable, descriptive name your apps agree on (for example
+  /// `"Contoso.Shell.Default"`); it does not need to be a GUID. Must not be null or
+  /// empty. The `Id` is case-insensitive and must be a valid file-system folder
+  /// name; otherwise the call fails with `E_INVALIDARG`.
   [propget] HRESULT Id([out, retval] LPWSTR* id);
   /// Sets the `Id` property.
   [propput] HRESULT Id([in] LPCWSTR id);
@@ -273,10 +347,8 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   /// Sets the `AreBrowserExtensionsEnabled` property.
   [propput] HRESULT AreBrowserExtensionsEnabled([in] BOOL value);
 
-  /// When TRUE (the default), the effective profile name is namespaced per host
-  /// application (`"<HostName>_<ProfileName>"`, where `<HostName>` is the host
-  /// executable name on Windows) to prevent accidental cross-app profile use. This
-  /// is not a security boundary.
+  /// When TRUE (the default), profile names are isolated per host application to
+  /// prevent accidental cross-app profile use. This is not a security boundary.
   [propget] HRESULT PerHostProfileIsolation([out, retval] BOOL* value);
   /// Sets the `PerHostProfileIsolation` property.
   [propput] HRESULT PerHostProfileIsolation([in] BOOL value);
@@ -295,31 +367,51 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
 
 /// Receives the result of `CreateOrJoinCoreWebView2ClusterEnvironment`.
 interface ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler : IUnknown {
-  /// `errorCode` is:
-  ///  * `S_OK` - `environment` is the shared cluster environment, either freshly
-  ///    established or attached to an existing cluster with matching options.
-  ///  * `ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH` - a cluster already exists for
-  ///    this `Id` with different options; `environment` is null.
+  /// When `errorCode` is `S_OK`, `status` describes the outcome:
+  ///  * `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_SUCCEEDED` - `environment` is the
+  ///    shared cluster environment.
+  ///  * `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH` - a cluster
+  ///    already exists for this `Id` with different options; `environment` is null.
+  ///
+  /// When `errorCode` is a failing `HRESULT`, the operation failed for another reason
+  /// (for example, the WebView2 Runtime could not be found), `status` is not
+  /// meaningful, and `environment` is null.
   HRESULT Invoke(
       [in] HRESULT errorCode,
+      [in] COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS status,
       [in] ICoreWebView2Environment* environment);
 }
 ```
-
-`ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH` is returned as
-`HRESULT_FROM_WIN32(ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH)`.
 
 ## .NET/WinRT
 
 The two global functions are surfaced as static methods on `CoreWebView2Environment`,
 mirroring how `CreateCoreWebView2EnvironmentWithOptions` maps to
-`CoreWebView2Environment.CreateAsync`. `GetClusterEnvironmentOptions` is synchronous
-and returns `null` when no cluster is configured, matching the `ERROR_NOT_FOUND` case
-of the COM API.
+`CoreWebView2Environment.CreateAsync`. `CreateOrJoinClusterEnvironmentAsync` returns a
+`CoreWebView2ClusterEnvironmentCreateResult` carrying the `Status` and, on success,
+the `Environment`. When the operation cannot be started or fails, it throws; in
+particular a host that cannot share or access the cluster's user data folder (for
+example a sandboxed or low-integrity process such as a UWP app) throws a
+`COMException` whose `HResult` is `HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)`.
+`GetClusterEnvironmentOptions` is synchronous and returns `null` when no cluster is
+configured, matching the `ERROR_NOT_FOUND` case of the COM API.
 
 ```c#
 namespace Microsoft.Web.WebView2.Core
 {
+    enum CoreWebView2ClusterEnvironmentStatus
+    {
+        Succeeded = 0,
+        OptionsMismatch = 1,
+    };
+
+    runtimeclass CoreWebView2ClusterEnvironmentCreateResult
+    {
+        CoreWebView2ClusterEnvironmentStatus Status { get; };
+        // Non-null only when Status is Succeeded.
+        CoreWebView2Environment Environment { get; };
+    }
+
     runtimeclass CoreWebView2ClusterEnvironmentOptions
     {
         CoreWebView2ClusterEnvironmentOptions();
@@ -338,15 +430,20 @@ namespace Microsoft.Web.WebView2.Core
     {
         // ...
 
-        // Establishes, or attaches to, the shared cluster identified by
-        // options.Id. Throws a COMException whose HResult is
-        // HRESULT_FROM_WIN32(ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH) when a
-        // cluster already exists for that Id with different options.
-        static Windows.Foundation.IAsyncOperation<CoreWebView2Environment>
+        // Establishes, or attaches to, the shared cluster identified by options.Id.
+        // The result's Status reports the outcome (Succeeded or OptionsMismatch);
+        // Environment is non-null only when Status is Succeeded. Throws when the
+        // operation cannot be started or fails, including
+        // HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) when the host cannot share or
+        // access the cluster's user data folder (for example a sandboxed or
+        // low-integrity process such as a UWP app).
+        static Windows.Foundation.IAsyncOperation<CoreWebView2ClusterEnvironmentCreateResult>
             CreateOrJoinClusterEnvironmentAsync(CoreWebView2ClusterEnvironmentOptions options);
 
         // Synchronously reads the options of the cluster identified by id. Returns
-        // null when no cluster is configured for id.
+        // null when no cluster is configured for id. Throws a COMException whose
+        // HResult is HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED) when the host cannot
+        // share or access the cluster's user data folder.
         static CoreWebView2ClusterEnvironmentOptions GetClusterEnvironmentOptions(
             String id);
     }

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -48,6 +48,10 @@ those hosts agree on out of band (for example a constant in a shared header). Al
 hosts that establish a cluster with the same `Id` run inside one browser process
 tree and one on-disk user data folder.
 
+Unlike `CreateCoreWebView2EnvironmentWithOptions`, you do **not** pass a user data
+folder. The runtime derives the folder from the cluster `Id` through a fixed
+mapping, so every host that uses the same `Id` resolves to the same on-disk layout.
+
 The **pinned options** are the `ICoreWebView2ClusterEnvironmentOptions` that the
 first host to establish the cluster supplied. Because a browser process tree is a
 single process-wide configuration, those options cannot differ per host, so the
@@ -104,9 +108,22 @@ void AppWindow::CreateSharedEnvironment()
     wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> pinned;
     HRESULT hr = GetCoreWebView2ClusterEnvironmentOptions(kClusterId, &pinned);
 
-    // Step 2 - reuse the pinned set if the cluster already exists, else offer my own.
-    wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> options =
-        (hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND)) ? BuildMyOptions() : pinned;
+    // Step 2 - reuse the pinned set if the cluster already exists; offer my own if
+    // nothing is pinned yet. Any other failure is a real error.
+    wil::com_ptr<ICoreWebView2ClusterEnvironmentOptions> options;
+    if (SUCCEEDED(hr))
+    {
+        options = pinned;
+    }
+    else if (hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND))
+    {
+        options = BuildMyOptions();
+    }
+    else
+    {
+        CHECK_FAILURE(hr);
+        return;
+    }
 
     // Step 3 - same symmetric create either way: establishes, or attaches to an
     // identical cluster.
@@ -240,9 +257,8 @@ STDAPI CreateCoreWebView2ClusterEnvironment(
 /// remains authoritative and validates against the live cluster.
 ///
 /// State: the pinned options are persisted per cluster `Id` in the user data folder
-/// resolved from that `Id` (a per-`Id` record). The record survives after the
-/// cluster's browser process exits, so `Get` answers whether or not the cluster is
-/// currently running. See the Appendix for the full behavior guarantees.
+/// resolved from that `Id`. The record survives after the cluster's browser process
+/// exits, so `Get` answers whether or not the cluster is currently running.
 STDAPI GetCoreWebView2ClusterEnvironmentOptions(
     [in] LPCWSTR id,
     [out] ICoreWebView2ClusterEnvironmentOptions** options);
@@ -254,6 +270,12 @@ STDAPI GetCoreWebView2ClusterEnvironmentOptions(
 interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   /// The rendezvous name that identifies the cluster. All cooperating hosts agree
   /// on this value out of band. Must not be null or empty.
+  ///
+  /// Because the `Id` is mapped to an on-disk user data folder, it is treated as a
+  /// case-insensitive name and must be a valid file-system folder name: it cannot
+  /// contain path separators or characters that are invalid in a folder name, and
+  /// its length must fit within the platform path limit once combined with the
+  /// runtime's base path. An invalid `Id` fails the call with `E_INVALIDARG`.
   [propget] HRESULT Id([out, retval] LPWSTR* id);
   /// Sets the `Id` property.
   [propput] HRESULT Id([in] LPCWSTR id);
@@ -336,7 +358,10 @@ The two global functions are surfaced as static methods on `CoreWebView2Environm
 mirroring how `CreateCoreWebView2EnvironmentWithOptions` maps to
 `CoreWebView2Environment.CreateAsync`. `GetClusterEnvironmentOptions` is synchronous
 and returns `null` when nothing is pinned (rather than throwing), matching the
-`ERROR_NOT_FOUND` case of the COM API.
+`ERROR_NOT_FOUND` case of the COM API. It is deliberately synchronous even though it
+reads persisted state: the read is small and bounded, and the whole point of the
+pre-flight is to let a host decide *before* it begins the async create, without
+threading an extra `await` through startup code.
 
 ```c#
 namespace Microsoft.Web.WebView2.Core
@@ -380,24 +405,6 @@ namespace Microsoft.Web.WebView2.Core
 
 # Appendix
 
-## Behavior guarantees
-
-The following are the observable guarantees a caller can rely on; the storage and
-locking that back them are runtime implementation details.
-
-- **First-creator-wins.** The first host to establish a cluster for an `Id` pins its
-  options. A later host with an identical set attaches; a host with a different set
-  gets `ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH`.
-- **`Get` works whether or not the cluster is running.** The pinned set is remembered
-  for the `Id` after the cluster's browser exits, so `Get` can answer with no browser
-  spawned. `Get` reads configuration, not liveness.
-- **The live cluster is authoritative.** `Get` is only a hint and can race; `Create`
-  validates against the running cluster, so a stale or absent pinned set is
-  self-healing (the next `Create` attaches if options match, or returns
-  `OPTIONS_MISMATCH` to re-read and retry). Concurrent creates never observe a
-  partially-established cluster or a half-written option set. Nothing needs a
-  background sweep.
-
 ## Alternatives considered
 
 Two other API shapes were evaluated and rejected in favor of this one.
@@ -411,64 +418,13 @@ Two other API shapes were evaluated and rejected in favor of this one.
   rendezvous and no lockable "establish" step. This model was chosen because it makes
   sharing explicit; the getter-only shape remains a smaller-surface fallback.
 
-## Why these options are process-wide
+## Relationship to existing options
 
-`ICoreWebView2ClusterEnvironmentOptions` deliberately excludes options that cannot
-hold a single value across a shared process tree. Some flags (for example the
-remote-debugging port or logging) are process-wide and can hold only one value, so
-in a cluster they are pinned by the first creator and are not per host. A model for
-per-app overrides inside a shared cluster is an open question (below).
+`ICoreWebView2ClusterEnvironmentOptions` is a new type rather than a reuse of
+`ICoreWebView2EnvironmentOptions`. It intentionally exposes only the options that can
+hold a single value across a shared browser process tree, plus the cluster `Id`.
+Options that cannot be shared process-wide (for example the remote-debugging port or
+logging, which the whole process can hold only one of) are omitted, so a host cannot
+set something on a cluster that would silently be ignored. The pinned set therefore
+belongs to the first creator and is not per host.
 
-## API-shape decisions for reviewers
-
-**New options type vs. extending `ICoreWebView2EnvironmentOptions`.** This spec adds
-a *new* `ICoreWebView2ClusterEnvironmentOptions` rather than reusing or extending the
-existing `ICoreWebView2EnvironmentOptions`. The tradeoff:
-
-- *New type (chosen).* Lets the surface expose *only* the options that are valid to
-  share process-wide, plus the cluster `Id`. Options that cannot hold a single value
-  across a shared process (see above) simply do not exist on the type, so a host
-  cannot set something that would silently be ignored. Cost: a parallel type that
-  duplicates several members already present on `ICoreWebView2EnvironmentOptions`,
-  and a small ongoing burden to keep the shared subset in sync as the existing
-  options type grows.
-- *Extend the existing type.* Would avoid duplication and let hosts reuse option-
-  building code (the getter-only alternative B does exactly this). Cost: the existing
-  type carries members that are meaningless or unsafe when shared, so the API would
-  have to document per-member "ignored in a cluster" behavior instead of omitting it.
-
-Reviewers should confirm the "omit what can't be shared" goal is worth the duplication
-before this is locked in; if not, the fallback is to accept an
-`ICoreWebView2EnvironmentOptions` plus a separate `Id` parameter.
-
-**How the mismatch surfaces in .NET/WinRT.** This spec projects the mismatch as a
-`COMException` whose `HResult` equals a static `OptionsMismatchHResult`, which is
-functional but not idiomatic for WinRT (callers must compare an HRESULT in a `catch`
-filter). An alternative worth considering is returning a result object or status
-enum from `CreateClusterEnvironmentAsync` (for example a
-`CoreWebView2ClusterEnvironmentCreateResult` with `Environment` and a `Status` of
-`Succeeded` / `OptionsMismatch`), so the mismatch is a normal return value rather
-than an exception. The COM handler already models this as a non-fault HRESULT, so
-either projection is possible.
-
-## Open questions
-
-- **Get semantics when not running.** Whether `Get` should return the pinned options
-  only while the cluster is running, or also when it is configured but not running.
-  This spec recommends the latter (forward-stable record) so `Get` can answer with
-  no browser spawned.
-- **Stronger profile-data security.** Real isolation (encryption with an app key, or
-  an OS-defined ACL) is out of scope; today `PerHostProfileIsolation` is anti-misuse
-  only and profile data in RAM is unencrypted.
-- **Renderer-process sharing across apps.** Under memory pressure the browser can
-  reduce site isolation and two hosts could share a renderer. Enterprise/vendor
-  renderers should be explicitly blocked from sharing.
-- **Per-app overrides in a shared cluster.** Process-wide flags can hold only one
-  value, so an override becomes per *cluster*, not per app; a per-app customization
-  model is unresolved.
-- **Coordinated option changes and shutdown.** Apps update on different timelines, so
-  a ready-to-restart or voting mechanism may be needed to apply an option change or
-  an upgrade consistently across a cluster. Today an option change lands on the next
-  app update or restart, and coordinating it is the apps' responsibility.
-- **Strict full-set equality is coarse.** An extensions-on vs extensions-off nuance
-  fails equality for both hosts; a finer compatibility model may be wanted later.

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -275,12 +275,6 @@ interface ICoreWebView2ClusterEnvironmentOptions : IUnknown {
   /// Sets the `AreBrowserExtensionsEnabled` property.
   [propput] HRESULT AreBrowserExtensionsEnabled([in] BOOL value);
 
-  /// The channel search kind used to locate the WebView2 Runtime.
-  [propget] HRESULT ChannelSearchKind(
-      [out, retval] COREWEBVIEW2_CHANNEL_SEARCH_KIND* value);
-  /// Sets the `ChannelSearchKind` property.
-  [propput] HRESULT ChannelSearchKind([in] COREWEBVIEW2_CHANNEL_SEARCH_KIND value);
-
   /// When TRUE (the default), the effective profile name is namespaced per host
   /// application (`"<HostName>_<ProfileName>"`, where `<HostName>` is the host
   /// executable name on Windows) to prevent accidental cross-app profile use. This
@@ -338,7 +332,6 @@ namespace Microsoft.Web.WebView2.Core
         Boolean AllowSingleSignOnUsingOSPrimaryAccount { get; set; };
         Boolean EnableTrackingPrevention { get; set; };
         Boolean AreBrowserExtensionsEnabled { get; set; };
-        CoreWebView2ChannelSearchKind ChannelSearchKind { get; set; };
         Boolean PerHostProfileIsolation { get; set; };
         IVector<CoreWebView2CustomSchemeRegistration> CustomSchemeRegistrations { get; };
     }

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -171,6 +171,10 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
 // A stable rendezvous name that all cooperating hosts agree on.
 const string ClusterId = "Contoso.Shell.Default";
 
+// HRESULT_FROM_WIN32(ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH). Matches the value
+// thrown as a COMException.HResult when the pinned set differs from ours.
+const int OptionsMismatchHResult = unchecked((int)0x8007139F);
+
 CoreWebView2ClusterEnvironmentOptions BuildMyOptions()
 {
     return new CoreWebView2ClusterEnvironmentOptions()
@@ -199,7 +203,8 @@ async Task CreateSharedEnvironmentAsync()
         OnSharedEnvironmentReady(environment);
     }
     catch (COMException ex) when
-        (ex.HResult == CoreWebView2ClusterEnvironmentOptions.OptionsMismatchHResult)
+        // The HRESULT of ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH.
+        (ex.HResult == OptionsMismatchHResult)
     {
         // A live browser pinned a different set since my Get. Re-read and retry, or
         // fall back to a private environment.
@@ -377,10 +382,6 @@ namespace Microsoft.Web.WebView2.Core
         CoreWebView2ChannelSearchKind ChannelSearchKind { get; set; };
         Boolean PerHostProfileIsolation { get; set; };
         IVector<CoreWebView2CustomSchemeRegistration> CustomSchemeRegistrations { get; };
-
-        // HRESULT of the options-mismatch failure, for callers that catch
-        // COMException from CreateOrJoinClusterEnvironmentAsync.
-        static Int32 OptionsMismatchHResult { get; };
     }
 
     runtimeclass CoreWebView2Environment
@@ -388,8 +389,9 @@ namespace Microsoft.Web.WebView2.Core
         // ...
 
         // Establishes, or attaches to, the shared cluster identified by
-        // options.Id. Throws a COMException with HResult == OptionsMismatchHResult
-        // when a cluster already exists for that Id with a different pinned set.
+        // options.Id. Throws a COMException whose HResult is
+        // HRESULT_FROM_WIN32(ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH) when a
+        // cluster already exists for that Id with a different pinned set.
         static Windows.Foundation.IAsyncOperation<CoreWebView2Environment>
             CreateOrJoinClusterEnvironmentAsync(CoreWebView2ClusterEnvironmentOptions options);
 

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -6,8 +6,8 @@ Shared WebView2 Cluster Environment
 Today an application gets a WebView2 by calling
 [`CreateCoreWebView2EnvironmentWithOptions`](https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions)
 and passing a `UserDataFolder` (UDF). Two hosts that pass the *same* UDF already
-share a single browser process tree, which is how multiple WebView2 hosts save
-memory today. But that sharing is implicit: it is keyed entirely on the UDF path,
+share a single browser process tree. But that sharing is implicit: it is keyed
+entirely on the UDF path,
 the first launcher silently pins the environment options for everyone else, and a
 second host has no way to learn what those pinned options are before it attaches.
 If the second host's options disagree with the pinned set, it only finds out after

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -395,79 +395,48 @@ async Task CreateSharedEnvironmentAsync()
 
 ## Deleting a cluster's user data folder
 
-WebView2 does not delete a cluster's user data folder automatically, even after the
-cluster's browser process exits. Cleaning it up is the cooperating applications' shared
-responsibility. Because several applications can use the same cluster, no single
-application should delete the folder while another might still use it. When the last
-cooperating application is being uninstalled, that application should delete the folder
-so it is not left behind on disk.
+WebView2 does not delete a cluster's user data folder automatically. Cleaning it up is
+the cooperating applications' shared responsibility. Because several applications can
+use the same cluster, the folder must not be deleted until every cooperating application
+has been uninstalled.
 
-Before deleting, the application must confirm that no other cooperating application is
-still using the cluster and that the cluster is not running (a cluster exists only
-while its browser process is running, and the folder cannot be deleted while it is in
-use). How an application tracks the remaining cooperating applications, for example a
-shared install registration or reference count, is app-specific and outside the scope
-of this API.
+### Save the folder path when the cluster is created
+
+The folder path can only be read from a live environment, and by uninstall time there is
+no environment left to ask. Each application should therefore read `UserDataFolder` when
+it first creates or joins the cluster and persist the path somewhere that outlives the
+application's installation.
 
 ```cpp
-// Called during uninstall of a cooperating application.
-void AppWindow::DeleteClusterUserDataFolderOnUninstall()
-{
-    // 1. App-specific check: proceed only if this is the last cooperating
-    //    application, so no other application is still using this cluster.
-    if (OtherClusterAppsStillInstalled(kClusterName))
-        return;
-
-    // 2. Read the cluster's user data folder path from the environment this
-    //    application joined.
-    wil::unique_cotaskmem_string userDataFolder;
-    CHECK_FAILURE(m_clusterEnvironment->get_UserDataFolder(&userDataFolder));
-
-    // 3. The folder cannot be deleted while the shared browser process is running, so
-    //    delete it once BrowserProcessExited reports that the process has fully exited,
-    //    then release all references to let it exit. This is the same pattern used to
-    //    delete an ordinary user data folder.
-    std::wstring folder = userDataFolder.get();
-    CHECK_FAILURE(m_clusterEnvironment->add_BrowserProcessExited(
-        Microsoft::WRL::Callback<ICoreWebView2BrowserProcessExitedEventHandler>(
-            [folder](ICoreWebView2Environment*,
-                     ICoreWebView2BrowserProcessExitedEventArgs*) -> HRESULT
-            {
-                DeleteDirectoryRecursive(folder.c_str());
-                return S_OK;
-            }).Get(),
-        nullptr));
-    m_clusterEnvironment.reset();
-}
+// After CreateOrJoinClusterEnvironment succeeds.
+wil::unique_cotaskmem_string userDataFolder;
+CHECK_FAILURE(m_clusterEnvironment->get_UserDataFolder(&userDataFolder));
+SaveClusterUserDataFolderPath(userDataFolder.get());
 ```
-
-The .NET equivalent uses the `UserDataFolder` property and the `BrowserProcessExited`
-event in the same way:
 
 ```c#
-// Called during uninstall of a cooperating application.
-void DeleteClusterUserDataFolderOnUninstall()
-{
-    // 1. App-specific check: proceed only if this is the last cooperating
-    //    application, so no other application is still using this cluster.
-    if (OtherClusterAppsStillInstalled(SharedClusterName))
-        return;
-
-    // 2. Read the cluster's user data folder path from the environment this
-    //    application joined.
-    string userDataFolder = m_clusterEnvironment.UserDataFolder;
-
-    // 3. The folder cannot be deleted while the shared browser process is running, so
-    //    delete it once BrowserProcessExited reports that the process has fully exited,
-    //    then release all references to let it exit. This is the same pattern used to
-    //    delete an ordinary user data folder.
-    m_clusterEnvironment.BrowserProcessExited += (sender, args) =>
-    {
-        Directory.Delete(userDataFolder, recursive: true);
-    };
-    m_clusterEnvironment = null;
-}
+// After CreateOrJoinClusterEnvironmentAsync succeeds.
+SaveClusterUserDataFolderPath(m_clusterEnvironment.UserDataFolder);
 ```
+
+### Delete the folder once the last application is uninstalled
+
+Deleting the folder requires that no cooperating application remains installed and that
+the cluster is not running. A cluster exists only while its browser process is running,
+and the folder cannot be deleted while it is in use. How an application determines that
+the other cooperating applications have been uninstalled is app-specific and outside the
+scope of this API.
+
+How the deletion is triggered depends on the installer technology:
+
+- **MSI**: perform the check and delete the saved folder path from an uninstall custom
+  action or uninstall script.
+- **MSIX**: packages cannot run code on uninstall, so an application cannot delete the
+  folder as part of its own removal. Instead, register a scheduled task that runs
+  independently of the package, checks whether all cooperating applications, including
+  the one that registered the task, have been uninstalled, and deletes the saved folder
+  path once they have. The task should remove itself after it has cleaned up so it does
+  not remain registered indefinitely.
 
 # API Details
 

--- a/specs/SharedClusterEnvironment.md
+++ b/specs/SharedClusterEnvironment.md
@@ -7,17 +7,17 @@ Today an application gets a WebView2 by calling
 [`CreateCoreWebView2EnvironmentWithOptions`](https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions)
 and passing a `UserDataFolder` (UDF). Two hosts that pass the *same* UDF already
 share a single browser process tree. But that sharing is implicit: it is keyed
-entirely on the UDF path,
-the first launcher silently pins the environment options for everyone else, and a
-second host has no way to learn what those pinned options are before it attaches.
-If the second host's options disagree with the pinned set, it only finds out after
-it has already paid to launch, and the failure surfaces as a generic create error.
+entirely on the UDF path, the first launcher silently pins the environment options
+for everyone else, and a second host has no way to learn what those pinned options
+are before it attaches. If the second host's options disagree with the pinned set,
+it only finds out after it has already paid to launch, and the failure surfaces as a
+generic create error.
 
 We want a first-class, *explicit* way for a set of cooperating host apps to opt into
 one shared WebView2 environment — a "cluster" — and to agree on the shared options up
 front.
 
-This spec proposes the **symmetric `Create` + synchronous `Get`** model:
+This spec proposes the **symmetric create-or-join + synchronous `Get`** model:
 
 - Every host calls the same symmetric `CreateOrJoinCoreWebView2ClusterEnvironment` with
   its full desired options. The **first** host to establish a cluster with a given
@@ -58,7 +58,7 @@ The recommended usage pattern is **"Get, then Create"**:
 2. If something is pinned, reuse it (attach). If nothing is pinned yet, offer your
    own options (you become the pinner).
 3. Call `CreateOrJoinCoreWebView2ClusterEnvironment` with the chosen options. You either
-   establish the cluster or attach to an identical one.
+   establish the cluster or attach to one with matching options.
 
 `Get` is only a hint: it can race with another host that pins a different set the
 instant after you read. The live browser stays authoritative, so `Create` still
@@ -77,8 +77,8 @@ profile name can use a shared profile.
 
 The example shows the recommended "Get, then Create" flow: read the pinned options
 for a well-known cluster id, reuse them if the cluster already exists, otherwise
-offer your own; then create (which either establishes the cluster or attaches to an
-identical one). On a mismatch, re-read the authoritative options and retry.
+offer your own; then create (which either establishes the cluster or attaches to one
+with matching options). On a mismatch, re-read the authoritative options and retry.
 
 ```cpp
 // A stable rendezvous name that all cooperating hosts agree on (e.g. in a shared header).
@@ -117,8 +117,8 @@ void AppWindow::CreateSharedEnvironment()
         return;
     }
 
-    // Step 3 - same symmetric create either way: establishes, or attaches to an
-    // identical cluster.
+    // Step 3 - same symmetric create either way: establishes, or attaches to a
+    // cluster with matching options.
     CreateSharedEnvironmentWithOptions(options.get());
 }
 
@@ -149,7 +149,7 @@ void AppWindow::CreateSharedEnvironmentWithOptions(
                 }
                 CHECK_FAILURE(result);
 
-                // Established the cluster, or attached to an identical one.
+                // Established the cluster, or attached to one with matching options.
                 OnSharedEnvironmentReady(environment);
                 return S_OK;
             })
@@ -194,9 +194,7 @@ async Task CreateSharedEnvironmentAsync()
             await CoreWebView2Environment.CreateOrJoinClusterEnvironmentAsync(options);
         OnSharedEnvironmentReady(environment);
     }
-    catch (COMException ex) when
-        // The HRESULT of ERROR_CLUSTER_ENVIRONMENT_OPTIONS_MISMATCH.
-        (ex.HResult == OptionsMismatchHResult)
+    catch (COMException ex) when (ex.HResult == OptionsMismatchHResult)
     {
         // A live browser pinned a different set since my Get. Re-read and retry, or
         // fall back to a private environment.
@@ -364,10 +362,4 @@ namespace Microsoft.Web.WebView2.Core
 meaningful for a shared cluster. Every option on it is process-wide: it takes a
 single value for the whole browser process, supplied by the first host to establish
 the cluster and shared by every host that attaches. There is no per-host override.
-
-This first iteration intentionally omits the options that select or locate the
-WebView2 Runtime itself, such as `BrowserExecutableFolder`,
-`TargetCompatibleBrowserVersion`, and the release-channel options (`ReleaseChannels`
-and `ChannelSearchKind`). These can be added later on a derived options interface
-without breaking compatibility.
 


### PR DESCRIPTION
This pull request introduces the specification for a **Shared WebView2 Cluster Environment**, a first-class, explicit way for a set of cooperating host applications to opt into one shared WebView2 environment (a "cluster") and agree on the shared options up front. Today apps can share a browser process only implicitly by passing the same user data folder; this API makes the sharing intent explicit, keyed on a well-known `ClusterName`, with a clear options-match contract and a way to read a cluster's options before joining.

### New APIs:

* **`CreateOrJoinCoreWebView2ClusterEnvironment(options, handler)`** — Symmetric create-or-join. The first host to establish a cluster for a given `ClusterName` fixes the cluster's options (first-creator-wins). A later host with matching options attaches to the running cluster; a host with different options receives `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS_OPTIONS_MISMATCH`.
* **`GetCoreWebView2ClusterEnvironmentOptions(clusterName, options)`** — Synchronously reads a running cluster's options without launching the shared browser process, so a host can decide before joining.

### New Interfaces and Enums:

* `ICoreWebView2ClusterEnvironmentOptions` — the shared options (`ClusterName`, `AdditionalBrowserArguments`, `Language`, `AllowSingleSignOnUsingOSPrimaryAccount`, `EnableTrackingPrevention`, `AreBrowserExtensionsEnabled`, `PerHostProfileIsolation`, `ReleaseChannels`, `ChannelSearchKind`, `CustomSchemeRegistrations`).
* `ICoreWebView2ClusterEnvironmentCreateResult` — `Status` plus `Environment` (non-null only when the status is Succeeded).
* `ICoreWebView2CreateOrJoinClusterEnvironmentCompletedHandler` — completion handler for the create-or-join operation.
* `COREWEBVIEW2_CLUSTER_ENVIRONMENT_STATUS` — `Succeeded`, `OptionsMismatch`.

### Details covered in the spec:

* User-data-folder derivation from `ClusterName`, lifetime and liveness model, options-matching semantics, trust/identity/session model, host-dependent option resolution, the loader-override contract, and user-data-folder deletion guidance.
* C++ and .NET/WinRT code samples for the create-or-join flow and for deleting a cluster's user data folder, plus the .NET/WinRT projection.
